### PR TITLE
Fix typos in doc

### DIFF
--- a/doc/source/reference/element.rst
+++ b/doc/source/reference/element.rst
@@ -13,7 +13,7 @@ and Space objects such as :class:`~space.UserSpace`.
 An *element* of a :class:`~cells.Cells` object is identified
 by arguments to the :class:`~cells.Cells`.
 If the :class:`~cells.Cells` has a value for the arguments,
-whether it's calculted or input, the :meth:`~node.ItemNode.has_value`
+whether it's calculated or input, the :meth:`~node.ItemNode.has_value`
 returns :obj:`True` and :attr:`~node.ItemNode.value` returns the value.
 Similarly to the :class:`~cells.Cells` element,
 an element of a Space is identified by arguments to the Space.

--- a/doc/source/tutorial/basic_operations.rst
+++ b/doc/source/tutorial/basic_operations.rst
@@ -533,7 +533,7 @@ Defining formulas
 -----------------
 
 Most Formulas need to reference values of other Cells
-and References to calculte their own values.
+and References to calculate their own values.
 Unlike Python functions,
 the name binding for modelx Formulas is independent from
 Python modules.

--- a/doc/source/tutorial/eval_formulas.rst
+++ b/doc/source/tutorial/eval_formulas.rst
@@ -39,7 +39,7 @@ Namespaces for Formulas
 --------------------------
 
 Most Formulas need to reference values of other Cells
-and References to calculte their own values.
+and References to calculate their own values.
 Unlike Python functions,
 the name binding for modelx Formulas is independent from
 Python modules.

--- a/modelx/core/node.py
+++ b/modelx/core/node.py
@@ -208,7 +208,7 @@ class ItemNode(BaseNode):
     An *element* of a :class:`~modelx.core.cells.Cells` object is identified
     by arguments to the :class:`~modelx.core.cells.Cells`.
     If the :class:`~modelx.core.cells.Cells` has a value for the arguments,
-    whether it's calculted or input, the :meth:`has_value`
+    whether it's calculated or input, the :meth:`has_value`
     returns :obj:`True` and :attr:`value` returns the value.
     Similarly to the :class:`~modelx.core.cells.Cells` element,
     an element of a Space is identified by arguments to the Space.


### PR DESCRIPTION
There are a couple of typos on the front page of modelx.io, I wanted to fix these but I couldn't find them in the repository. I did find a couple in the repository though.

Typos on the front page of modelx.io (I could not find them in the repository):
* pupulate -> populate
* mechanisims -> mechanisms
* calcultaion -> calculation
* versitile -> versatile
* spacifications -> specifications
* associatd -> associated
* parametrizing -> parameterizing