### PR TITLE
ENH: Add Model.path property

### DIFF
--- a/doc/source/reference/model.rst
+++ b/doc/source/reference/model.rst
@@ -16,6 +16,7 @@ Model properties
   ~Model.name
   ~Model.fullname
   ~Model.doc
+  ~Model.path
   ~Model.model
   ~Model.parent
   ~Model.allow_none

--- a/modelx/core/base.py
+++ b/modelx/core/base.py
@@ -591,12 +591,12 @@ null_interface = Interface(null_impl)
 
 class ChainObserver:
     __slots__ = ()
-    __mixin_slots = ("is_fresh", "observers", "observing")
+    __mixin_slots = ("is_fresh", "observers", "subjects")
 
     def __init__(self, observers=None):
         self.is_fresh = True    # Define here so that LazyEval can notify this
         self.observers = []
-        self.observing = []
+        self.subjects = []
         if observers:
             for observer in observers:
                 self.append_observer(observer)
@@ -608,13 +608,13 @@ class ChainObserver:
         # if observer not in self.observers:
         if all(observer is not other for other in self.observers):
             self.observers.append(observer)
-            observer.observing.append(self)
+            observer.subjects.append(self)
             if notify:
                 observer.notify()
 
     def remove_observer(self, observer):
         self.observers.remove(observer)
-        observer.observing.remove(self)
+        observer.subjects.remove(self)
 
     def observe(self, other, notify=True):
         other.append_observer(self, notify)
@@ -645,7 +645,7 @@ class LazyEval(ChainObserver):
     @property
     def fresh(self):
         if not self.is_fresh:
-            for other in self.observing:
+            for other in self.subjects:
                 other.fresh
             self._refresh()
             self.is_fresh = True

--- a/modelx/core/base.py
+++ b/modelx/core/base.py
@@ -233,6 +233,27 @@ class Impl(BaseImpl):
     def __repr__(self):
         return self.get_repr(fullname=True, add_params=True)
 
+    # ----------------------------------------------------------------------
+    # Inspection tools
+
+    def get_members_dict(self):
+        mro = self.__class__.__mro__
+        result = {}
+        all_mixin_slots = []
+        for cls in reversed(mro):
+            slots = cls.__slots__ if hasattr(cls, "__slots__") else ()
+            mixin_attr = "_" + cls.__name__ + "__mixin_slots"
+            mixin_slots = getattr(cls, mixin_attr) if hasattr(cls, mixin_attr) else ()
+            all_mixin_slots.extend(mixin_slots)
+
+            if slots:
+                names = [n for n in slots if n not in all_mixin_slots]
+                type_names = [type(getattr(self, n)).__name__ for n in names]
+                result[cls.__name__] = [n + ": " + t for n, t in zip(names, type_names)]
+            elif mixin_slots:
+                result[cls.__name__] = [n + ": " + type(getattr(self, n)).__name__ for n in mixin_slots]
+
+        return result
 
 class Derivable:
 

--- a/modelx/core/base.py
+++ b/modelx/core/base.py
@@ -252,6 +252,8 @@ class Impl(BaseImpl):
                 result[cls.__name__] = [n + ": " + t for n, t in zip(names, type_names)]
             elif mixin_slots:
                 result[cls.__name__] = [n + ": " + type(getattr(self, n)).__name__ for n in mixin_slots]
+            elif cls.__name__ != "object":
+                result[cls.__name__] = []
 
         return result
 

--- a/modelx/core/base.py
+++ b/modelx/core/base.py
@@ -591,6 +591,7 @@ class Interface:
 
 null_interface = Interface(null_impl)
 
+
 class ChainObserver:
     __slots__ = ()
     __mixin_slots = ("is_fresh", "observers", "subjects")
@@ -602,6 +603,7 @@ class ChainObserver:
         if observers:
             for observer in observers:
                 self.append_observer(observer)
+
     def notify(self):
         raise NotImplementedError
 

--- a/modelx/core/model.py
+++ b/modelx/core/model.py
@@ -355,7 +355,57 @@ class Model(IOSpecOperation, EditableParent):
 
     @property
     def path(self):
-        # TODO: Temporary
+        r"""A Path object representing the model's path.
+
+        When a previously saved model is loaded with :func:`~modelx.read_model`,
+        this property is set to a `pathlib.Path`_ object representing
+        the path given to :func:`~modelx.read_model`::
+
+            >>> import modelx as mx
+            >>> model = mx.read_model(r"C:\Users\mxuser\Model")
+            >>> model.path
+            WindowsPath('C:/Users/mxuser/Model2')
+
+        When a model is created with :py:func:`~modelx.new_model`,
+        this property is set to ``None``::
+
+            >>> model = mx.new_model()
+            >>> model.path     # Returns None
+
+        The user can set the path by assigning a string value to it::
+
+            >>> model.path = "."
+            >>> model.path
+            WindowsPath('.')
+
+        When a model is saved with :meth:`~Model.write` or
+        :func:`~modelx.write_model`,
+        this property is updated to a `pathlib.Path`_ object representing
+        the path given to the method or function::
+
+            >>> model.write(r"C:\Users\mxuser\Model2")
+            >>> model.path
+            WindowsPath('C:/Users/mxuser/Model2')
+
+        The property is accessed within formulas as an attribute
+        of a special Reference, ``model_``::
+
+            >>> @mx.defcells
+            >>> def foo():
+            ...     return _model.path
+            >>> foo()
+            WindowsPath('C:/Users/mxuser/Model')
+
+        Returns:
+            A `pathlib.Path`_ object or :py:obj:`None`
+
+        .. versionadded:: 0.25.0
+
+        .. _pathlib.Path:
+           https://docs.python.org/3/library/pathlib.html#pathlib.Path
+
+        """
+        # TODO: Temporary Implementation
         if self._impl.system.callstack.counter:
             self._impl.system.refstack.append(
                 (self._impl.system.callstack.counter - 1,

--- a/modelx/core/model.py
+++ b/modelx/core/model.py
@@ -122,6 +122,20 @@ class ReferenceGraph(nx.DiGraph):
         self.remove_nodes_from((ref, *desc))
         return desc     # Not including ref
 
+    def remove_with_referred(self, nodes):
+        """Remove nodes that refer to ref nodes.
+
+        If the referred ref nodes become isolated, also remove them.
+        """
+        refs = []
+        for n in nodes:
+            if self.has_node(n):
+                refs.extend(self.predecessors(n))
+        self.remove_nodes_from(nodes)
+        for n in refs:
+            if self.degree(n) == 0:
+                self.remove_node(n)
+
 
 class IOSpecOperation:
 
@@ -675,14 +689,14 @@ class TraceManager:
     def clear_with_descs(self, node):
         """Clear values and nodes calculated from `source`."""
         removed = self.tracegraph.remove_with_descs(node)
-        self.refgraph.remove_nodes_from(removed)
+        self.refgraph.remove_with_referred(removed)
         for node in removed:
             node[OBJ].on_clear_trace(node[KEY])
 
     def clear_obj(self, obj):
         """Clear values and nodes of `obj` and their dependants."""
         removed = self.tracegraph.clear_obj(obj)
-        self.refgraph.remove_nodes_from(removed)
+        self.refgraph.remove_with_referred(removed)
         for node in removed:
             node[OBJ].on_clear_trace(node[KEY])
 

--- a/modelx/core/model.py
+++ b/modelx/core/model.py
@@ -365,6 +365,7 @@ class Model(IOSpecOperation, EditableParent):
 
     @path.setter
     def path(self, path):
+        self._impl.clear_attr_referrers(self._impl.property_refs["path"])
         self._impl.path = pathlib.Path(path)
         self._impl.property_refs.set_item("path", self._impl.path)
 
@@ -830,7 +831,6 @@ class ModelImpl(*_model_impl_base):
         self._global_refs.set_item("__builtins__", builtins)
         self._property_refs = RefDict("property_refs", self)
         self._property_refs.set_item("path", self.path)
-        self._global_refs.observe(self._property_refs)
         self._named_spaces = SpaceDict("named_spaces", self)
         self._dynamic_bases = SpaceDict("dynamic_bases", self)
         self._all_spaces = ImplChainMap("all_spaces",

--- a/modelx/core/model.py
+++ b/modelx/core/model.py
@@ -332,7 +332,7 @@ class Model(IOSpecOperation, EditableParent):
 
     def close(self):
         """Close the model."""
-        self._impl.close()
+        self._impl.system.close_model(self._impl)
 
     @Interface.doc.setter
     def doc(self, value):
@@ -839,9 +839,6 @@ class ModelImpl(*_model_impl_base):
     @property
     def namespace(self):
         return self._namespace.fresh
-
-    def close(self):
-        self.system.close_model(self)
 
     def get_impl_from_name(self, name):
         """Retrieve an object by a dotted name relative to the model."""

--- a/modelx/core/space.py
+++ b/modelx/core/space.py
@@ -79,7 +79,7 @@ class ParamFunc(Formula):
 
 class SpaceDict(ImplDict):
 
-    __slots__ = get_mixin_slots(ImplDict)
+    __slots__ = ()
 
     def __init__(self, name, space, data=None, observers=None):
         ImplDict.__init__(self, name, space, SpaceView, data, observers)
@@ -87,7 +87,7 @@ class SpaceDict(ImplDict):
 
 class CellsDict(ImplDict):
 
-    __slots__ = get_mixin_slots(ImplDict)
+    __slots__ = ()
 
     def __init__(self, name, space, data=None, observers=None):
         ImplDict.__init__(self, name, space, CellsView, data, observers)
@@ -95,7 +95,7 @@ class CellsDict(ImplDict):
 
 class RefDict(ImplDict):
 
-    __slots__ = get_mixin_slots(ImplDict)
+    __slots__ = ()
 
     def __init__(self, name, parent, data=None, observers=None):
         ImplDict.__init__(self, name, parent, RefView, None, observers)
@@ -123,6 +123,8 @@ class RefDict(ImplDict):
 
 
 class DynBaseRefDict(RefDict):
+
+    __slots__ = ()
 
     def wrap_impl(self, parent, name, value):
 

--- a/modelx/core/space.py
+++ b/modelx/core/space.py
@@ -1377,7 +1377,8 @@ class BaseSpaceImpl(*_base_space_impl_base):
         self._own_refs = self._init_own_refs()
         self._cells = CellsDict("cells", self)
         self._named_spaces = SpaceDict("named_spaces", self)
-        self._sys_refs = LazyEvalDict("sys_refs", {"_self": self, "_space": self})
+        self._sys_refs = LazyEvalDict("sys_refs",
+                                      {"_self": self, "_space": self, "_model": self.model})
         self._refs = self._init_refs(arguments)
 
         NamespaceServer.__init__(

--- a/modelx/export/_mx_sys.py
+++ b/modelx/export/_mx_sys.py
@@ -38,6 +38,8 @@ class BaseParent(BaseMxObject):
 
 class BaseModel(BaseParent):
 
+    path = pathlib.Path(__file__).parent
+
     def _mx_load_io(self):
 
         ios = {}
@@ -45,16 +47,16 @@ class BaseModel(BaseParent):
         if has_io:
             for k, v in _mx_io.ios.items():
                 cls = io_types[v['type']]
-                load_from = pathlib.Path(__file__).parent / k
+                load_from = self.path / k
                 ios[k] = cls(k, load_from, v)
 
             for k, v in _mx_io.iospecs.items():
                 cls = iospec_types[v['type']]
                 io_data[k] = cls(ios[v['io']], v['kwargs']).load_value()
 
-        path = pathlib.Path(__file__).parent / '_mx_pickled'
-        if path.exists():
-            with open(path, mode='rb') as f:
+        p = self.path / '_mx_pickled'
+        if p.exists():
+            with open(p, mode='rb') as f:
                 pickle_data = pickle.load(f)
         else:
             pickle_data = {}

--- a/modelx/serialize/__init__.py
+++ b/modelx/serialize/__init__.py
@@ -81,6 +81,8 @@ def write_model(system, model, model_path,
                            compresslevel=compresslevel
                            ).write_model()
 
+    if model.path != root:
+        model.path = root
     return model
 
 
@@ -97,4 +99,6 @@ def read_model(system, model_path, name=None):
     else:
         serializer = _get_serializer(1)
 
-    return serializer.ModelReader(system, path).read_model(**kwargs)
+    model = serializer.ModelReader(system, path).read_model(**kwargs)
+    model.path = path
+    return model

--- a/modelx/tests/core/model/test_model_path.py
+++ b/modelx/tests/core/model/test_model_path.py
@@ -1,0 +1,35 @@
+import modelx as mx
+import pathlib
+
+
+def test_model_path(tmp_path):
+
+    m = mx.new_model()
+    s = m.new_space("Space1")
+
+    @mx.defcells(space=s)
+    def foo():
+        return _model.path
+
+    m.path = "."
+    assert foo() == pathlib.Path(".")
+
+    m.path = ".."
+    assert foo() == pathlib.Path("..")
+
+    m.write(tmp_path / "model")
+    assert foo() == tmp_path / "model"
+
+    m.path = "."
+    assert foo() == pathlib.Path(".")
+
+    m.close()
+    m = mx.read_model(tmp_path / "model")
+    assert m.Space1.foo() == tmp_path / "model"
+
+    ref = m.Space1.foo.precedents()[0]
+    assert ref.obj.name == "path"
+    assert ref.obj.value == tmp_path / "model"
+
+
+

--- a/modelx/tests/core/space/test_space.py
+++ b/modelx/tests/core/space/test_space.py
@@ -31,7 +31,7 @@ def test_refs(testmodel):
 
 
 def test_dir(testmodel):
-    assert {"foo", "bar", "_self", "_space", "__builtins__"} == set(
+    assert {"foo", "bar", "_self", "_space", "__builtins__", "_model"} == set(
         dir(testmodel.testspace)
     )
 

--- a/modelx/tests/export/samples/ModelPath/Space1/__init__.py
+++ b/modelx/tests/export/samples/ModelPath/Space1/__init__.py
@@ -1,0 +1,17 @@
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def foo():
+    return _model.path
+
+

--- a/modelx/tests/export/samples/ModelPath/__init__.py
+++ b/modelx/tests/export/samples/ModelPath/__init__.py
@@ -1,0 +1,10 @@
+from modelx.serialize.jsonvalues import *
+
+_name = "Model1"
+
+_allow_none = False
+
+_spaces = [
+    "Space1"
+]
+

--- a/modelx/tests/export/samples/ModelPath/_system.json
+++ b/modelx/tests/export/samples/ModelPath/_system.json
@@ -1,0 +1,1 @@
+{"modelx_version": [0, 24, 0], "serializer_version": 6}

--- a/modelx/tests/export/test_export.py
+++ b/modelx/tests/export/test_export.py
@@ -224,3 +224,18 @@ def test_relative_refs2(tmp_path_factory):
     finally:
         sys.path.pop(0)
         m.close()
+
+
+def test_model_path(tmp_path_factory):
+    nomx_path = tmp_path_factory.mktemp('model')
+    m = mx.read_model(sample_dir / "ModelPath")
+    m.export(nomx_path / 'ModelPath_nomx')
+
+    try:
+        sys.path.insert(0, str(nomx_path))
+        from ModelPath_nomx import mx_model
+        assert mx_model.Space1.foo() == nomx_path / 'ModelPath_nomx'
+
+    finally:
+        sys.path.pop(0)
+        m.close()


### PR DESCRIPTION
The pull request introduces a new property `path` to the `Model` class. This property holds the path from which the model is loaded or to which it is saved, represented as a `pathlib.Path` object. This property can be accessed within formulas using the special reference `_model.path`.