### PR TITLE
FIX: get_node_repr crash on unhashable key when is_cached=False

### DIFF
--- a/modelx/core/execution/trace.py
+++ b/modelx/core/execution/trace.py
@@ -106,7 +106,7 @@ def get_node_repr(node: TraceNode) -> str:
         "%s=%s" % (param, arg) for param, arg in zip(params, key)
     )
 
-    if key in obj.data:
+    if obj.is_cached and key in obj.data:
         return name + "(" + arglist + ")" + "=" + str(obj.data[key])
     else:
         return name + "(" + arglist + ")"

--- a/modelx/tests/core/cells/test_error.py
+++ b/modelx/tests/core/cells/test_error.py
@@ -49,6 +49,37 @@ def test_none_returned_error():
     m.close()
 
 
+def test_formula_error_uncached_unhashable():
+    """Regression: formula traceback formatting must not assume keys are
+    hashable when is_cached=False (formulas with unhashable args, e.g.
+    lists, would crash get_node_repr with TypeError otherwise)."""
+
+    errfunc = dedent(
+        """\
+        def raise_zerodiv(x):
+            return 1 / 0"""
+    )
+
+    m = mx.new_model(name="ErrModelUncached")
+    space = m.new_space(name="ErrSpace")
+    cells = space.new_cells(formula=errfunc)
+    cells.is_cached = False
+
+    with ConfigureExecutor():
+        with pytest.raises(ZeroDivisionError):
+            cells([1, 2, 3])
+
+    with pytest.raises(FormulaError) as errinfo:
+        cells([1, 2, 3])
+
+    assert "ErrModelUncached.ErrSpace.raise_zerodiv(x=[1, 2, 3])" in (
+        errinfo.value.args[0]
+    )
+
+    m._impl._check_sanity()
+    m.close()
+
+
 def test_zerodiv():
 
     zerodiv = dedent(


### PR DESCRIPTION
## Summary

- `get_node_repr` in `modelx/core/execution/trace.py` (line 109) tested `key in obj.data` without first checking `obj.is_cached`. When `is_cached=False`, formula keys may be unhashable (e.g. list arguments — the documented use case for disabling caching), so the membership test raised `TypeError: unhashable type: 'list'`, masking the real exception.
- The crash is reachable from `ErrorStack.tracemessage` (`modelx/core/execution/executor.py:414`) whenever an uncached cell raises an exception while called with an unhashable argument.
- Fix: guard the membership test with `obj.is_cached`, matching the precedent at `modelx/core/execution/executor.py:34`. Since `obj.data` is empty when `is_cached=False`, short-circuiting is both safe and correct.

## Test plan

- [x] Added `test_formula_error_uncached_unhashable` in `modelx/tests/core/cells/test_error.py`. Verified it reproduces the original `TypeError` against the unfixed code, and passes after the fix.
- [x] `pytest modelx/tests/core/cells/` — 94 passed, 1 pre-existing skip, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)