### PR TITLE
FIX: exporter crash on model-level (global) references

### DIFF
--- a/modelx/export/exporter.py
+++ b/modelx/export/exporter.py
@@ -240,11 +240,15 @@ class ParentTranslator:
 
             if isinstance(v, (Cells, BaseSpace)):
 
-                refmode = parent._get_object(k, as_proxy=True).refmode
+                proxy = parent._get_object(k, as_proxy=True)
+                refmode = proxy.refmode
                 if refmode == 'auto' or refmode == 'relative':
                     if_clause = 'if ' + (base_k + '.__self__' if isinstance(v, Cells) else base_k) + '._mx_is_in(base_root) else ' + base_k
                     result.append(self_k + ' = ' + self.ref_value(parent, v) + ' ' + if_clause)
-                elif refmode == 'absolute':
+                elif refmode == 'absolute' or (
+                        refmode is None and isinstance(proxy.parent, Model)):
+                    # refmode is None for model-level (global) references,
+                    # which are inherited unchanged across spaces.
                     result.append(self_k + ' = ' + base_k)
                 else:
                     raise RuntimeError('must not happen')

--- a/modelx/tests/export/samples/ConstExample/Consts/ProductID/__init__.py
+++ b/modelx/tests/export/samples/ConstExample/Consts/ProductID/__init__.py
@@ -1,0 +1,23 @@
+# modelx: pseudo-python
+# This file is part of a modelx model.
+# It can be imported as a Python module, but functions defined herein
+# are model formulas and may not be executable as standard Python.
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# References
+
+TERM = 1
+
+WL = 2
+
+ENDW = 3

--- a/modelx/tests/export/samples/ConstExample/Consts/__init__.py
+++ b/modelx/tests/export/samples/ConstExample/Consts/__init__.py
@@ -1,0 +1,17 @@
+# modelx: pseudo-python
+# This file is part of a modelx model.
+# It can be imported as a Python module, but functions defined herein
+# are model formulas and may not be executable as standard Python.
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = [
+    "ProductID"
+]
+

--- a/modelx/tests/export/samples/ConstExample/Foo/__init__.py
+++ b/modelx/tests/export/samples/ConstExample/Foo/__init__.py
@@ -1,0 +1,22 @@
+# modelx: pseudo-python
+# This file is part of a modelx model.
+# It can be imported as a Python module, but functions defined herein
+# are model formulas and may not be executable as standard Python.
+
+from modelx.serialize.jsonvalues import *
+
+_formula = None
+
+_bases = []
+
+_allow_none = None
+
+_spaces = []
+
+# ---------------------------------------------------------------------------
+# Cells
+
+def foo(product_str):
+    return getattr(ProductID, product_str)
+
+

--- a/modelx/tests/export/samples/ConstExample/__init__.py
+++ b/modelx/tests/export/samples/ConstExample/__init__.py
@@ -1,0 +1,20 @@
+# modelx: pseudo-python
+# This file is part of a modelx model.
+# It can be imported as a Python module, but functions defined herein
+# are model formulas and may not be executable as standard Python.
+
+from modelx.serialize.jsonvalues import *
+
+_name = "ConstExample"
+
+_allow_none = False
+
+_spaces = [
+    "Consts",
+    "Foo"
+]
+
+# ---------------------------------------------------------------------------
+# References
+
+ProductID = ("Interface", (".", "Consts", "ProductID"), "None")

--- a/modelx/tests/export/samples/ConstExample/_system.json
+++ b/modelx/tests/export/samples/ConstExample/_system.json
@@ -1,0 +1,1 @@
+{"modelx_version": [0, 30, 1], "serializer_version": 6}

--- a/modelx/tests/export/test_export.py
+++ b/modelx/tests/export/test_export.py
@@ -366,4 +366,27 @@ def test_space_properties(tmp_path_factory):
 
     finally:
         sys.path.pop(0)
+
+
+def test_model_level_ref(tmp_path):
+    """Model-level (global) references have refmode=None.
+
+    Regression test: Exporter.ref_copies must accept refmode=None for refs
+    owned by the Model when the space inherits them as global refs.
+    """
+    nomx_path = tmp_path / 'model'
+    m = mx.read_model(sample_dir / 'ConstExample')
+    try:
+        m.export(nomx_path / 'ConstExample_nomx')
+
+        sys.path.insert(0, str(nomx_path))
+        from ConstExample_nomx import mx_model as nomx
+
+        assert nomx.Foo.foo('TERM') == 1
+        assert nomx.Foo.foo('WL') == 2
+        assert nomx.Foo.foo('ENDW') == 3
+        assert nomx.ProductID is nomx.Consts.ProductID
+        assert nomx.Foo.ProductID is nomx.Consts.ProductID
+    finally:
+        sys.path.pop(0)
         m.close()


### PR DESCRIPTION
## Summary
- `Model.export()` raised `RuntimeError('must not happen')` from `Exporter.ref_copies` whenever a space inherited a model-level (global) reference (one assigned directly on the `Model`, not on a `UserSpace`).
- Such references go through `ModelImpl.new_ref`, which does not pass a `refmode`, so the underlying `ReferenceImpl.refmode` is `None`. The export branch only handled `'auto'`, `'relative'`, and `'absolute'`, so any model with a global ref crashed during export.

## Fix
- In `Exporter.ref_copies`, accept `refmode is None` **only** when the reference's owning parent is a `Model`, and emit `self.X = base.X` (the same code path as `absolute`). Model-level refs are inherited unchanged across spaces, so no inheritance adjustment is needed.
- A `None` refmode on a space-owned reference still raises — the strict check is preserved for the case that should never happen.

## Test
- Added `test_model_level_ref` in `modelx/tests/export/test_export.py`, using a new sample model `modelx/tests/export/samples/ConstExample/` that mirrors the user-reported case: a model-level reference `ProductID` pointing to a `UserSpace`, plus a sibling space `Foo` whose cell uses `getattr(ProductID, ...)`. The test exports the model, imports the `_nomx` package, and checks both the cell results and that `nomx.ProductID`, `nomx.Foo.ProductID`, and `nomx.Consts.ProductID` are the same object.

## Test plan
- [x] `pytest modelx/tests/export/` — 19 passed (was 18; 1 new)
- [x] `pytest modelx/tests/export/ modelx/tests/serialize/ modelx/tests/core/reference/` — 199 passed, 3 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)