### PR TITLE
FIX: Restore back-compat by moving pseudo-python header to serializer_7

### DIFF
--- a/modelx/core/base.py
+++ b/modelx/core/base.py
@@ -464,7 +464,7 @@ class Interface:
     def __reduce__(self):
         if self._is_valid() and self._impl.system.serializing:
 
-            if self._impl.system.serializing.version in (3, 4, 5, 6):
+            if self._impl.system.serializing.version in (3, 4, 5, 6, 7):
                 return self._reduce_serialize_3()
             else:
                 raise ValueError("invalid serializer version")

--- a/modelx/serialize/__init__.py
+++ b/modelx/serialize/__init__.py
@@ -17,7 +17,8 @@ _MX_TO_FORMAT = {
     (0, 2, 0): 3,
     (0, 9, 0): 4,
     (0, 18, 0): 5,
-    (0, 22, 0): 6
+    (0, 22, 0): 6,
+    (0, 30, 2): 7
 }
 
 HIGHEST_VERSION = list(_MX_TO_FORMAT.values())[-1]

--- a/modelx/serialize/serializer_6.py
+++ b/modelx/serialize/serializer_6.py
@@ -36,12 +36,6 @@ from .custom_pickle import (
     IOSpecUnpickler, ModelUnpickler,
     IOSpecPickler, ModelPickler)
 
-PSEUDO_PYTHON_HEADER = """\
-# modelx: pseudo-python
-# This file is part of a modelx model.
-# It can be imported as a Python module, but functions defined herein
-# are model formulas and may not be executable as standard Python."""
-
 
 class TupleID(tuple):
 
@@ -461,7 +455,7 @@ class ModelEncoder(BaseEncoder):
         )
 
     def encode(self):
-        lines = [PSEUDO_PYTHON_HEADER]
+        lines = []
         if self.model.doc is not None:
             lines.append("\"\"\"" + self.model.doc + "\"\"\"")
 
@@ -519,7 +513,7 @@ class SpaceEncoder(BaseEncoder):
 
     def encode(self):
 
-        lines = [PSEUDO_PYTHON_HEADER]
+        lines = []
         if self.space.doc is not None:
             lines.append("\"\"\"" + self.space.doc + "\"\"\"")
 
@@ -1043,11 +1037,12 @@ class DocstringParser(BaseNodeParser):
     """Docstring at module level"""
     @classmethod
     def condition(cls, stmt: StatementTokens):
-        # stmt has 1 element that is STRING.
+        # stmt has 1 element that is STRING and starts at line 1.
         if stmt.section == "DEFAULT" and len(stmt) == 1:
             elm = stmt[0]
             if elm.type == tokenize.STRING:
-                return True
+                if elm.start[0] == 1:
+                    return True
 
         return False
 

--- a/modelx/serialize/serializer_7.py
+++ b/modelx/serialize/serializer_7.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
+
+# This library is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation version 3.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Serializer version 7.
+
+Adds a pseudo-python header comment block to serialized ``__init__.py`` files
+on top of serializer 6. The DocstringParser is relaxed so the docstring no
+longer needs to start at line 1, allowing the header comments to come first.
+"""
+import sys
+import json
+import pathlib
+import tempfile
+import shutil
+import zipfile
+import tokenize
+import modelx as mx
+from . import ziputil
+from .deserializer import get_statement_tokens, StatementTokens
+from . import serializer_6
+
+
+PSEUDO_PYTHON_HEADER = """\
+# modelx: pseudo-python
+# This file is part of a modelx model.
+# It can be imported as a Python module, but functions defined herein
+# are model formulas and may not be executable as standard Python."""
+
+
+class ModelEncoder(serializer_6.ModelEncoder):
+
+    def encode(self):
+        return PSEUDO_PYTHON_HEADER + "\n\n" + super().encode()
+
+
+class SpaceEncoder(serializer_6.SpaceEncoder):
+
+    def encode(self):
+        return PSEUDO_PYTHON_HEADER + "\n\n" + super().encode()
+
+
+class DocstringParser(serializer_6.DocstringParser):
+    """Docstring at module level. Allows docstrings not on line 1."""
+    @classmethod
+    def condition(cls, stmt: StatementTokens):
+        # stmt has 1 element that is STRING.
+        if stmt.section == "DEFAULT" and len(stmt) == 1:
+            elm = stmt[0]
+            if elm.type == tokenize.STRING:
+                return True
+
+        return False
+
+
+class ParserSelector(serializer_6.BaseSelector):
+    classes = [
+        DocstringParser,
+        serializer_6.ImportFromParser,
+        serializer_6.RenameParser,
+        serializer_6.LambdaAssignParser,
+        serializer_6.LambdaDocstringParser,
+        serializer_6.ParentAttrAssignParser,
+        serializer_6.CellsAttrAssignParser,
+        serializer_6.RefAssignParser,
+        serializer_6.SpaceFuncDefParser,
+        serializer_6.CellsFuncDefParser
+    ]
+
+
+class ModelWriter(serializer_6.ModelWriter):
+
+    version = 7
+
+    def write_model(self):
+
+        try:
+            if self.is_zip:
+                tempdir = tempfile.TemporaryDirectory()
+                self.temp_root = pathlib.Path(tempdir.name) / self.root.name
+                self.work_dir = pathlib.Path(tempdir.name) / (self.root.stem + '_temp')
+                self.work_dir.mkdir(parents=True, exist_ok=True)
+
+            self.system.serializing = self
+            self.system.iomanager.serializing = True
+
+            ziputil.make_root(self.temp_root, self.is_zip, self.compression, self.compresslevel)
+            ziputil.write_str(json.dumps(
+                {"modelx_version": mx.VERSION[:3],
+                 "serializer_version": self.version}),
+                self.temp_root / "_system.json",
+                compression=self.compression,
+                compresslevel=self.compresslevel)
+
+            encoder = ModelEncoder(
+                self, self.model,
+                self.temp_root / "__init__.py",
+                self.temp_root / "_data")
+
+            self._write_recursive(encoder)
+            self.write_pickledata()
+            self.system.iomanager.write_ios(self.model, root=self.work_dir)
+
+            if self.log_input:
+                ziputil.write_str_utf8(
+                    "\n".join(self.input_log),
+                    self.temp_root / "_input_log.txt",
+                    compression=self.compression,
+                    compresslevel=self.compresslevel
+                )
+
+            if self.is_zip:
+                ziputil.archive_dir(self.work_dir, self.temp_root,
+                                    compression=self.compression,
+                                    compresslevel=self.compresslevel)
+                if self.root.exists() and self.root.is_dir():
+                    raise IOError("'%s' is an existing directory" % self.root.name)
+                else:
+                    shutil.move(self.temp_root, self.root)
+
+        finally:
+            self.system.serializing = None
+            self.system.iomanager.serializing = None
+            if self.is_zip:
+                tempdir.cleanup()
+
+    def _write_recursive(self, encoder):
+
+        ziputil.write_str_utf8(encoder.encode(), encoder.srcpath,
+                               compression=self.compression,
+                               compresslevel=self.compresslevel)
+
+        for space in encoder.target.spaces.values():
+
+            srcpath = (encoder.srcpath.parent / space.name / "__init__.py")
+
+            e = SpaceEncoder(
+                self,
+                space,
+                srcpath=srcpath
+                )
+            self._write_recursive(e)
+
+        encoder.instruct().execute()
+
+
+class ModelReader(serializer_6.ModelReader):
+
+    version = ModelWriter.version
+
+    def parse_source(self, path_, obj):
+
+        for stmt in get_statement_tokens(path_):
+            parser = ParserSelector.select(stmt)(
+                stmt, self, obj, srcpath=path_
+            )
+            parser.set_instruction()

--- a/modelx/tests/serialize/test_serialize.py
+++ b/modelx/tests/serialize/test_serialize.py
@@ -283,7 +283,7 @@ def test_false_value(tmp_path, write_method):
 
 
 def test_pseudo_python_header(tmp_path):
-    from modelx.serialize.serializer_6 import PSEUDO_PYTHON_HEADER
+    from modelx.serialize.serializer_7 import PSEUDO_PYTHON_HEADER
     m = mx.new_model("HeaderTest")
     s = m.new_space("Space1")
 


### PR DESCRIPTION
## Summary

- Reverts the pseudo-python header change applied to `serializer_6` in [e06c1c3](https://github.com/fumitoh/modelx/commit/e06c1c31322f5509387e1fec979545d97a909169) (#217), which broke modelx 0.28.0-0.30.1 when reading models saved by HEAD.
- Reintroduces the header as a new `serializer_7` that inherits from `serializer_6`, so the file format change is properly versioned.
- Registers serializer 7 as the highest version (mapped to the upcoming modelx 0.30.2) and whitelists it in `Interface.__reduce__`.

## Why

The four `# modelx: pseudo-python` header lines pushed the module docstring from line 1 to line 6. `serializer_6.DocstringParser.condition` required `elm.start[0] == 1`, so on older modelx no parser matched the docstring statement, `ParserSelector.select(...)` returned `None`, and `parse_source` crashed with:

```
File ".../modelx/serialize/serializer_6.py", line 969, in parse_source
    parser = ParserSelector.select(stmt)(stmt, self, obj, srcpath=path_)
TypeError: 'NoneType' object is not callable
```

Bumping the serializer version keeps serializer_6 readers working with serializer_6 files and uses serializer_7 for new writes.

## Changes

- [modelx/serialize/serializer_6.py](https://github.com/fumitoh/modelx/blob/claude/dreamy-roentgen-07ea2e/modelx/serialize/serializer_6.py): full revert of the e06c1c3 hunks (header constant, both `encode` calls, `DocstringParser.condition`).
- [modelx/serialize/serializer_7.py](https://github.com/fumitoh/modelx/blob/claude/dreamy-roentgen-07ea2e/modelx/serialize/serializer_7.py) (new): inherits from `serializer_6`. Subclasses `ModelEncoder`/`SpaceEncoder` to prepend `PSEUDO_PYTHON_HEADER` via `super().encode()`; a relaxed `DocstringParser` drops the line-1 requirement; `ParserSelector` swaps the new docstring parser into the classes list; `ModelWriter`/`ModelReader` override the small set of methods (`write_model`, `_write_recursive`, `parse_source`) that reference the encoder/parser classes via module globals.
- [modelx/serialize/__init__.py](https://github.com/fumitoh/modelx/blob/claude/dreamy-roentgen-07ea2e/modelx/serialize/__init__.py): `(0, 30, 2): 7` added to `_MX_TO_FORMAT`, making 7 the new `HIGHEST_VERSION` for writes.
- [modelx/core/base.py](https://github.com/fumitoh/modelx/blob/claude/dreamy-roentgen-07ea2e/modelx/core/base.py): added `7` to the valid-serializer-version tuple in `Interface.__reduce__` (v7 reuses the v3-v6 reduce path).
- [modelx/tests/serialize/test_serialize.py](https://github.com/fumitoh/modelx/blob/claude/dreamy-roentgen-07ea2e/modelx/tests/serialize/test_serialize.py): `test_pseudo_python_header` now imports `PSEUDO_PYTHON_HEADER` from `serializer_7`.

## Test plan

- [x] `pytest modelx/tests/serialize/` (116 passed, 2 skipped)
- [x] `pytest modelx/tests/` full suite (930 passed, 6 skipped)
- [x] `test_pseudo_python_header` confirms both model and space `__init__.py` start with the header and the model round-trips.
- [ ] Cross-version sanity check: open a model written by this branch with modelx 0.30.1 (should now succeed because writes still default to serializer_6 until released as 0.30.2... reviewer note: see "Reviewer notes" below).

## Reviewer notes

- `HIGHEST_VERSION` is `list(_MX_TO_FORMAT.values())[-1]`, i.e. the last entry in the dict. Adding `(0, 30, 2): 7` makes serializer_7 the default writer **immediately on this branch**, regardless of the modelx version string. If you'd rather keep serializer_6 as the default until a tagged 0.30.2 release, drop the new entry (or move it earlier in the dict) and force serializer_7 only when the user passes `version=7` explicitly.
- `ModelWriter.write_model` is duplicated verbatim from serializer_6 except for the `ModelEncoder(...)` line, because the parent looks up `ModelEncoder`/`SpaceEncoder` via serializer_6's module globals. If you'd prefer a smaller v7, I can refactor `serializer_6.ModelWriter` to factory-out `_make_model_encoder` / `_make_space_encoder` so v7 only overrides those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)