### PR TITLE
FIX: Clear error in read_model when path is not a modelx model

### DIFF
--- a/modelx/serialize/__init__.py
+++ b/modelx/serialize/__init__.py
@@ -118,14 +118,27 @@ def read_model(system, model_path, name=None):
 
     kwargs = {"name": name} if name else {}
     path = pathlib.Path(model_path)
+
+    if not path.exists():
+        raise FileNotFoundError(
+            "No such file or directory: %r" % str(model_path))
+    if not (path.is_dir() or zipfile.is_zipfile(path)):
+        raise ValueError(
+            "%r is not a modelx model: not a directory or zip file"
+            % str(model_path))
+
     params = _get_model_metadata(path)
 
     if params:
         serializer = _get_serializer(params["serializer_version"])
         if "modelx_version" in params:
             kwargs["modelx_version"] = tuple(params["modelx_version"])
-    else:
+    elif ziputil.exists(path / "_model.py"):
         serializer = _get_serializer(1)
+    else:
+        raise ValueError(
+            "%r is not a modelx model: missing '_system.json' at root"
+            % str(model_path))
 
     model = serializer.ModelReader(system, path).read_model(**kwargs)
     model.path = path


### PR DESCRIPTION
## Summary

- `mx.read_model(path)` against a non-modelx path used to raise a confusing `FileNotFoundError: ... '_model.py'` leaked from `serializer_1`. It now validates the path up-front and raises an actionable error.
- Legacy v0.0.25 models (which have `_model.py` at the root but no `_system.json`) continue to be read via `serializer_1` as before.

## What changed

In `modelx/serialize/__init__.py` `read_model`:

1. **Path missing** → `FileNotFoundError: No such file or directory: '<path>'`
2. **Path is neither a directory nor a zip file** → `ValueError: '<path>' is not a modelx model: not a directory or zip file`. Detected via `zipfile.is_zipfile` (content-based), so zipped models with arbitrary names still work.
3. **No `_system.json` at the root and no legacy `_model.py` marker** → `ValueError: '<path>' is not a modelx model: missing '_system.json' at root`.
4. **Legacy fallback** — when only `_model.py` is present at the root, fall through to `_get_serializer(1)` exactly as before.

## Background

`_system.json` was introduced in modelx v0.1.0 (commit `a763a1a7`, 2019-11-01; released 2019-12-01). modelx v0.0.25 and earlier had no `serialize` package at all and saved models with `_model.py` at the root only. Legacy support for those very old models is preserved.

## Test plan

- [x] `mx.read_model("does_not_exist")` raises `FileNotFoundError` with the path
- [x] `mx.read_model(<plain text file>)` raises `ValueError` "not a directory or zip file"
- [x] `mx.read_model(<empty dir>)` raises `ValueError` "missing '_system.json' at root"
- [x] `mx.read_model(<unrelated zip>)` raises `ValueError` "missing '_system.json' at root"
- [x] `mx.read_model(<extensionless zip>)` raises `ValueError` "missing '_system.json' at root"
- [x] Happy path: write and read a real model still works
- [x] `pytest modelx/tests/serialize` — 116 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)