### PR TITLE
Add validation for cached values in dependency graph methods

### DIFF
--- a/modelx/core/node.py
+++ b/modelx/core/node.py
@@ -12,7 +12,9 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-from modelx.core.execution.trace import OBJ, KEY, get_node, TraceObject
+from modelx.core.execution.trace import (
+    OBJ, KEY, get_node, get_node_repr, TraceObject
+)
 
 
 class BaseNode:
@@ -345,13 +347,28 @@ class BaseNodeFactoryImpl:
     # ----------------------------------------------------------------------
     # Dependency
 
+    def _check_cached(self, node):
+        obj = node[OBJ]
+        if not obj.is_cached:
+            raise ValueError(
+                "%s is not cached"
+                % obj.get_repr(fullname=True, add_params=False)
+            )
+        if not obj.has_node(node[KEY]):
+            raise ValueError(
+                "%s has no cached value for the given arguments"
+                % get_node_repr(node)
+            )
+
     def predecessors(self, args, kwargs):
         node = get_node(self, args, kwargs)
+        self._check_cached(node)
         preds = self.model.tracegraph.predecessors(node)
         return [ObjectNode(n) if len(n) < 2 else ItemNode(n) for n in preds]
 
     def successors(self, args, kwargs):
         node = get_node(self, args, kwargs)
+        self._check_cached(node)
         succs = self.model.tracegraph.successors(node)
         return [ItemNode(n) for n in succs]
 

--- a/modelx/tests/core/cells/test_cache.py
+++ b/modelx/tests/core/cells/test_cache.py
@@ -130,3 +130,38 @@ def test_unhashable_arg():
     assert foo.precedents(0)[0].args is None
 
     m.close()
+
+
+@pytest.mark.parametrize("method", ["preds", "succs", "precedents"])
+def test_no_cached_value_error(method):
+    """preds/succs/precedents on a cells without a cached value for the key
+    raises a clear ValueError instead of a NetworkXError.
+    """
+    m = mx.new_model()
+    s = m.new_space()
+
+    @mx.defcells(space=s)
+    def foo(t):
+        return t * 2
+
+    with pytest.raises(ValueError, match="no cached value"):
+        getattr(foo, method)(0)
+
+    m.close()
+
+
+@pytest.mark.parametrize("method", ["preds", "succs", "precedents"])
+def test_uncached_cells_error(method):
+    """preds/succs/precedents on an uncached cells raises a clear ValueError."""
+    m = mx.new_model()
+    s = m.new_space()
+
+    @mx.defcells(space=s, is_cached=False)
+    def foo(t):
+        return t * 2
+
+    foo(0)
+    with pytest.raises(ValueError, match="not cached"):
+        getattr(foo, method)(0)
+
+    m.close()


### PR DESCRIPTION
## Summary
This PR adds proper error handling and validation to the `predecessors`, `successors`, and `precedents` methods to ensure they only operate on cells with cached values, providing clear error messages instead of cryptic NetworkXError exceptions.

## Key Changes
- **Added `_check_cached()` validation method** in `BaseNodeFactoryImpl` that verifies:
  - The cells object has caching enabled (`is_cached`)
  - A cached value exists for the given arguments
  - Raises descriptive `ValueError` messages in both cases

- **Updated dependency graph methods** to call `_check_cached()` before accessing the trace graph:
  - `predecessors()` - checks cache before retrieving predecessors
  - `successors()` - checks cache before retrieving successors

- **Added comprehensive test coverage** with two new test functions:
  - `test_no_cached_value_error()` - validates error when a cached cells has no value for given arguments
  - `test_uncached_cells_error()` - validates error when using uncached cells
  - Both tests parametrized to cover all three methods (`preds`, `succs`, `precedents`)

- **Updated imports** in `node.py` to include `get_node_repr` helper function for generating user-friendly error messages

## Implementation Details
The validation is performed early in the dependency graph methods to fail fast with user-friendly error messages rather than allowing the code to proceed and encounter internal NetworkXError exceptions. Error messages clearly indicate whether the issue is that caching is disabled or that no cached value exists for the given arguments.

https://claude.ai/code/session_015maDpz8THPuubCxkGYdqzA