### PR TITLE
Add macro serialization support to modelx

### DIFF
--- a/modelx/__init__.py
+++ b/modelx/__init__.py
@@ -20,7 +20,7 @@ Attributes:
 
 """
 
-VERSION = (0, 30, 1)
+VERSION = (0, 31, 0)
 __version__ = ".".join([str(x) for x in VERSION])
 from modelx.core.api import *  # must come after __version__ assignment.
 try:

--- a/modelx/__init__.py
+++ b/modelx/__init__.py
@@ -20,7 +20,7 @@ Attributes:
 
 """
 
-VERSION = (0, 31, 0)
+VERSION = (0, 30, 1)
 __version__ = ".".join([str(x) for x in VERSION])
 from modelx.core.api import *  # must come after __version__ assignment.
 try:

--- a/modelx/core/macro.py
+++ b/modelx/core/macro.py
@@ -151,8 +151,8 @@ class MacroImpl(Impl):
         )
         
         if not isinstance(formula, Formula):
-            formula = Formula(formula)
-        
+            formula = Formula(formula, name=name)
+
         self.formula = formula
         self._namespace = None
     
@@ -190,7 +190,7 @@ class MacroImpl(Impl):
             func: New function to use as the formula
         """
         if not isinstance(func, Formula):
-            func = Formula(func)
+            func = Formula(func, name=self.name)
         self.formula = func
     
     def repr_parent(self):

--- a/modelx/serialize/serializer_7.py
+++ b/modelx/serialize/serializer_7.py
@@ -38,6 +38,24 @@ PSEUDO_PYTHON_HEADER = """\
 # are model formulas and may not be executable as standard Python."""
 
 
+MACROS_FILE = "_macros.py"
+
+
+class MacroEncoder(serializer_6.BaseEncoder):
+    """Encode a single ``MacroImpl`` as Python source.
+
+    Mirrors :class:`serializer_6.CellsEncoder` but writes to ``_macros.py``
+    instead of a space's ``__init__.py``. ``self.target`` is the Macro
+    interface (``model.macros[name]``).
+    """
+
+    def encode(self):
+        src = self.target.formula.source
+        if src[:6] == "lambda":
+            return self.target.name + " = " + src
+        return src
+
+
 class ModelEncoder(serializer_6.ModelEncoder):
 
     def encode(self):
@@ -108,6 +126,7 @@ class ModelWriter(serializer_6.ModelWriter):
                 self.temp_root / "_data")
 
             self._write_recursive(encoder)
+            self._write_macros()
             self.write_pickledata()
             self.system.iomanager.write_ios(self.model, root=self.work_dir)
 
@@ -153,6 +172,94 @@ class ModelWriter(serializer_6.ModelWriter):
 
         encoder.instruct().execute()
 
+    def _write_macros(self):
+        macros = self.model.macros
+        if not macros:
+            return
+
+        parts = [PSEUDO_PYTHON_HEADER]
+        for macro in macros.values():
+            parts.append(MacroEncoder(self, macro).encode())
+
+        ziputil.write_str_utf8(
+            "\n\n".join(parts) + "\n",
+            self.temp_root / MACROS_FILE,
+            compression=self.compression,
+            compresslevel=self.compresslevel,
+        )
+
+
+class MacroFuncDefParser(serializer_6.FunctionDefParser):
+    """``def name(...):`` at top level of ``_macros.py``."""
+
+    METHOD = "new_macro"
+
+    @classmethod
+    def condition(cls, stmt):
+        # No section filter: every top-level def in _macros.py is a macro.
+        return super(MacroFuncDefParser, cls).condition(stmt)
+
+    @property
+    def macroname(self):
+        return self.stmt[1].string
+
+    def set_instruction(self):
+        inst = serializer_6.Instruction.from_method(
+            obj=self.obj._impl,
+            method="new_macro",
+            kwargs={"name": self.macroname,
+                    "formula": self.get_funcdef()},
+        )
+        self.instructions.append(inst)
+        return inst
+
+
+class MacroLambdaAssignParser(serializer_6.BaseAssignParser):
+    """``name = lambda ...`` at top level of ``_macros.py``."""
+
+    @classmethod
+    def condition(cls, stmt):
+        if not super(MacroLambdaAssignParser, cls).condition(stmt):
+            return False
+        if len(stmt) < 3:
+            return False
+        return stmt[2].type == tokenize.NAME and stmt[2].string == "lambda"
+
+    @property
+    def macroname(self):
+        return self.stmt[0].string
+
+    def set_instruction(self):
+        # Reconstruct the lambda expression text in the same shape as
+        # serializer_6.LambdaAssignParser.set_instruction.
+        expr = ""
+        first_token = True
+        first_line = 0
+        for tok in self.stmt[2:]:
+            if first_token:
+                expr += tok.line[tok.start[1]:]
+                first_line = tok.start[0]
+                first_token = False
+            elif tok.start[0] == first_line:
+                continue
+            else:
+                expr += tok.line
+
+        inst = serializer_6.Instruction.from_method(
+            obj=self.obj._impl,
+            method="new_macro",
+            kwargs={"name": self.macroname, "formula": expr},
+        )
+        self.instructions.append(inst)
+        return inst
+
+
+class MacroParserSelector(serializer_6.BaseSelector):
+    classes = [
+        MacroLambdaAssignParser,
+        MacroFuncDefParser,
+    ]
+
 
 class ModelReader(serializer_6.ModelReader):
 
@@ -165,3 +272,38 @@ class ModelReader(serializer_6.ModelReader):
                 stmt, self, obj, srcpath=path_
             )
             parser.set_instruction()
+
+    def parse_macros(self):
+        macro_path = self.path / MACROS_FILE
+        if not ziputil.exists(macro_path):
+            return
+        for stmt in get_statement_tokens(macro_path):
+            parser_cls = MacroParserSelector.select(stmt)
+            if parser_cls is None:
+                continue
+            parser = parser_cls(stmt, self, self.model, srcpath=macro_path)
+            parser.set_instruction()
+
+    def _read_model_inner(self):
+        model = self.parse_dir()
+        self.parse_macros()
+        self.instructions.execute_selected_methods([
+            "doc",
+            "set_formula",
+            "set_property",
+            "_new_cells_keep_source",
+            "new_cells",
+            "set_doc",
+            "new_macro",
+        ])
+        self.instructions.execute_selected_methods(["add_bases"])
+        self.read_pickledata()
+        self.instructions.execute_selected_methods(["load_pickledata"])
+        self.instructions.execute_selected_methods(
+            ["__setattr__", "set_ref"])
+        self.instructions.execute_selected_methods(
+            ["_set_dynamic_inputs"])
+
+        assert not self.instructions
+
+        return model

--- a/modelx/tests/serialize/test_macro_serialize.py
+++ b/modelx/tests/serialize/test_macro_serialize.py
@@ -1,0 +1,196 @@
+import json
+import pytest
+import modelx as mx
+
+
+def _close_all_models():
+    for model in list(mx.get_models().values()):
+        model.close()
+
+
+@pytest.fixture(autouse=True)
+def isolate_models():
+    _close_all_models()
+    yield
+    _close_all_models()
+
+
+def test_macro_roundtrip_funcdef(tmp_path):
+    m = mx.new_model("MacroRT")
+
+    @mx.defmacro
+    def get_name():
+        return mx_model._name
+
+    @mx.defmacro
+    def add(a, b):
+        return a + b
+
+    mx.write_model(m, tmp_path / "model")
+    _close_all_models()
+
+    m2 = mx.read_model(tmp_path / "model")
+    assert set(m2.macros) == {"get_name", "add"}
+    assert m2.get_name() == "MacroRT"
+    assert m2.add(2, 3) == 5
+
+
+def test_macro_roundtrip_lambda(tmp_path):
+    m = mx.new_model("LambdaRT")
+    m.new_macro("dbl", lambda x: x * 2)
+
+    mx.write_model(m, tmp_path / "model")
+    _close_all_models()
+
+    m2 = mx.read_model(tmp_path / "model")
+    assert "dbl" in m2.macros
+    assert m2.dbl(5) == 10
+
+
+def test_macro_calling_another_macro(tmp_path):
+    m = mx.new_model("Chain")
+
+    @mx.defmacro
+    def base():
+        return 21
+
+    @mx.defmacro
+    def double_base():
+        return base() * 2
+
+    mx.write_model(m, tmp_path / "model")
+    _close_all_models()
+
+    m2 = mx.read_model(tmp_path / "model")
+    assert m2.double_base() == 42
+
+
+def test_macro_accesses_mx_model_and_model_name(tmp_path):
+    m = mx.new_model("AccessTest")
+
+    @mx.defmacro
+    def via_mx_model():
+        return mx_model._name
+
+    @mx.defmacro
+    def via_model_name():
+        return AccessTest._name
+
+    mx.write_model(m, tmp_path / "model")
+    _close_all_models()
+
+    m2 = mx.read_model(tmp_path / "model")
+    assert m2.via_mx_model() == "AccessTest"
+    assert m2.via_model_name() == "AccessTest"
+
+
+def test_macro_params_and_kwargs(tmp_path):
+    m = mx.new_model("ParamsRT")
+
+    @mx.defmacro
+    def greet(name, greeting="Hello"):
+        return f"{greeting}, {name}!"
+
+    mx.write_model(m, tmp_path / "model")
+    _close_all_models()
+
+    m2 = mx.read_model(tmp_path / "model")
+    assert m2.greet("World") == "Hello, World!"
+    assert m2.greet("World", greeting="Hi") == "Hi, World!"
+
+
+def test_macro_renamed_via_defmacro_name(tmp_path):
+    # @defmacro(name='custom') decorating def original should serialize
+    # under the registered name, not the original function name.
+    m = mx.new_model("RenameRT")
+
+    @mx.defmacro(model=m, name="custom_name")
+    def original_name():
+        return mx_model._name
+
+    mx.write_model(m, tmp_path / "model")
+    _close_all_models()
+
+    m2 = mx.read_model(tmp_path / "model")
+    assert "custom_name" in m2.macros
+    assert "original_name" not in m2.macros
+    assert m2.custom_name() == "RenameRT"
+
+
+def test_mixed_macros_cells_refs_spaces(tmp_path):
+    m = mx.new_model("Mixed")
+    s = m.new_space("S")
+
+    @mx.defcells
+    def foo(x):
+        return x * 10
+
+    m.scalar = 7
+
+    @mx.defmacro
+    def use_space():
+        return mx_model.S.foo(3)
+
+    @mx.defmacro
+    def use_ref():
+        return mx_model.scalar + 1
+
+    mx.write_model(m, tmp_path / "model")
+    _close_all_models()
+
+    m2 = mx.read_model(tmp_path / "model")
+    assert m2.S.foo(3) == 30
+    assert m2.scalar == 7
+    assert m2.use_space() == 30
+    assert m2.use_ref() == 8
+
+
+def test_no_macros_no_file_emitted(tmp_path):
+    m = mx.new_model("NoMacros")
+    m.new_space("S")
+
+    mx.write_model(m, tmp_path / "model")
+    assert not (tmp_path / "model" / "_macros.py").exists()
+
+    _close_all_models()
+    m2 = mx.read_model(tmp_path / "model")
+    assert len(m2.macros) == 0
+
+
+def test_macros_file_contains_pseudo_python_header(tmp_path):
+    m = mx.new_model("HeaderCheck")
+
+    @mx.defmacro
+    def f():
+        return 1
+
+    mx.write_model(m, tmp_path / "model")
+    content = (tmp_path / "model" / "_macros.py").read_text()
+    assert "# modelx: pseudo-python" in content
+    assert "def f():" in content
+
+
+def test_serializer_version_unchanged(tmp_path):
+    m = mx.new_model("Vcheck")
+
+    @mx.defmacro
+    def f():
+        return 1
+
+    mx.write_model(m, tmp_path / "model")
+    meta = json.loads((tmp_path / "model" / "_system.json").read_text())
+    assert meta["serializer_version"] == 7
+
+
+def test_macro_zip_roundtrip(tmp_path):
+    m = mx.new_model("ZipRT")
+
+    @mx.defmacro
+    def f():
+        return "zipped"
+
+    mx.write_model(m, tmp_path / "model.zip")
+    _close_all_models()
+
+    m2 = mx.read_model(tmp_path / "model.zip")
+    assert m2.f() == "zipped"

--- a/modelx/tests/serialize/test_macro_serialize.py
+++ b/modelx/tests/serialize/test_macro_serialize.py
@@ -1,18 +1,5 @@
 import json
-import pytest
 import modelx as mx
-
-
-def _close_all_models():
-    for model in list(mx.get_models().values()):
-        model.close()
-
-
-@pytest.fixture(autouse=True)
-def isolate_models():
-    _close_all_models()
-    yield
-    _close_all_models()
 
 
 def test_macro_roundtrip_funcdef(tmp_path):
@@ -27,12 +14,15 @@ def test_macro_roundtrip_funcdef(tmp_path):
         return a + b
 
     mx.write_model(m, tmp_path / "model")
-    _close_all_models()
+    m.close()
 
     m2 = mx.read_model(tmp_path / "model")
-    assert set(m2.macros) == {"get_name", "add"}
-    assert m2.get_name() == "MacroRT"
-    assert m2.add(2, 3) == 5
+    try:
+        assert set(m2.macros) == {"get_name", "add"}
+        assert m2.get_name() == "MacroRT"
+        assert m2.add(2, 3) == 5
+    finally:
+        m2.close()
 
 
 def test_macro_roundtrip_lambda(tmp_path):
@@ -40,11 +30,14 @@ def test_macro_roundtrip_lambda(tmp_path):
     m.new_macro("dbl", lambda x: x * 2)
 
     mx.write_model(m, tmp_path / "model")
-    _close_all_models()
+    m.close()
 
     m2 = mx.read_model(tmp_path / "model")
-    assert "dbl" in m2.macros
-    assert m2.dbl(5) == 10
+    try:
+        assert "dbl" in m2.macros
+        assert m2.dbl(5) == 10
+    finally:
+        m2.close()
 
 
 def test_macro_calling_another_macro(tmp_path):
@@ -59,10 +52,13 @@ def test_macro_calling_another_macro(tmp_path):
         return base() * 2
 
     mx.write_model(m, tmp_path / "model")
-    _close_all_models()
+    m.close()
 
     m2 = mx.read_model(tmp_path / "model")
-    assert m2.double_base() == 42
+    try:
+        assert m2.double_base() == 42
+    finally:
+        m2.close()
 
 
 def test_macro_accesses_mx_model_and_model_name(tmp_path):
@@ -77,11 +73,14 @@ def test_macro_accesses_mx_model_and_model_name(tmp_path):
         return AccessTest._name
 
     mx.write_model(m, tmp_path / "model")
-    _close_all_models()
+    m.close()
 
     m2 = mx.read_model(tmp_path / "model")
-    assert m2.via_mx_model() == "AccessTest"
-    assert m2.via_model_name() == "AccessTest"
+    try:
+        assert m2.via_mx_model() == "AccessTest"
+        assert m2.via_model_name() == "AccessTest"
+    finally:
+        m2.close()
 
 
 def test_macro_params_and_kwargs(tmp_path):
@@ -92,11 +91,14 @@ def test_macro_params_and_kwargs(tmp_path):
         return f"{greeting}, {name}!"
 
     mx.write_model(m, tmp_path / "model")
-    _close_all_models()
+    m.close()
 
     m2 = mx.read_model(tmp_path / "model")
-    assert m2.greet("World") == "Hello, World!"
-    assert m2.greet("World", greeting="Hi") == "Hi, World!"
+    try:
+        assert m2.greet("World") == "Hello, World!"
+        assert m2.greet("World", greeting="Hi") == "Hi, World!"
+    finally:
+        m2.close()
 
 
 def test_macro_renamed_via_defmacro_name(tmp_path):
@@ -109,12 +111,15 @@ def test_macro_renamed_via_defmacro_name(tmp_path):
         return mx_model._name
 
     mx.write_model(m, tmp_path / "model")
-    _close_all_models()
+    m.close()
 
     m2 = mx.read_model(tmp_path / "model")
-    assert "custom_name" in m2.macros
-    assert "original_name" not in m2.macros
-    assert m2.custom_name() == "RenameRT"
+    try:
+        assert "custom_name" in m2.macros
+        assert "original_name" not in m2.macros
+        assert m2.custom_name() == "RenameRT"
+    finally:
+        m2.close()
 
 
 def test_mixed_macros_cells_refs_spaces(tmp_path):
@@ -136,13 +141,16 @@ def test_mixed_macros_cells_refs_spaces(tmp_path):
         return mx_model.scalar + 1
 
     mx.write_model(m, tmp_path / "model")
-    _close_all_models()
+    m.close()
 
     m2 = mx.read_model(tmp_path / "model")
-    assert m2.S.foo(3) == 30
-    assert m2.scalar == 7
-    assert m2.use_space() == 30
-    assert m2.use_ref() == 8
+    try:
+        assert m2.S.foo(3) == 30
+        assert m2.scalar == 7
+        assert m2.use_space() == 30
+        assert m2.use_ref() == 8
+    finally:
+        m2.close()
 
 
 def test_no_macros_no_file_emitted(tmp_path):
@@ -152,9 +160,12 @@ def test_no_macros_no_file_emitted(tmp_path):
     mx.write_model(m, tmp_path / "model")
     assert not (tmp_path / "model" / "_macros.py").exists()
 
-    _close_all_models()
+    m.close()
     m2 = mx.read_model(tmp_path / "model")
-    assert len(m2.macros) == 0
+    try:
+        assert len(m2.macros) == 0
+    finally:
+        m2.close()
 
 
 def test_macros_file_contains_pseudo_python_header(tmp_path):
@@ -164,10 +175,13 @@ def test_macros_file_contains_pseudo_python_header(tmp_path):
     def f():
         return 1
 
-    mx.write_model(m, tmp_path / "model")
-    content = (tmp_path / "model" / "_macros.py").read_text()
-    assert "# modelx: pseudo-python" in content
-    assert "def f():" in content
+    try:
+        mx.write_model(m, tmp_path / "model")
+        content = (tmp_path / "model" / "_macros.py").read_text()
+        assert "# modelx: pseudo-python" in content
+        assert "def f():" in content
+    finally:
+        m.close()
 
 
 def test_serializer_version_unchanged(tmp_path):
@@ -177,9 +191,12 @@ def test_serializer_version_unchanged(tmp_path):
     def f():
         return 1
 
-    mx.write_model(m, tmp_path / "model")
-    meta = json.loads((tmp_path / "model" / "_system.json").read_text())
-    assert meta["serializer_version"] == 7
+    try:
+        mx.write_model(m, tmp_path / "model")
+        meta = json.loads((tmp_path / "model" / "_system.json").read_text())
+        assert meta["serializer_version"] == 7
+    finally:
+        m.close()
 
 
 def test_macro_zip_roundtrip(tmp_path):
@@ -190,7 +207,10 @@ def test_macro_zip_roundtrip(tmp_path):
         return "zipped"
 
     mx.write_model(m, tmp_path / "model.zip")
-    _close_all_models()
+    m.close()
 
     m2 = mx.read_model(tmp_path / "model.zip")
-    assert m2.f() == "zipped"
+    try:
+        assert m2.f() == "zipped"
+    finally:
+        m2.close()


### PR DESCRIPTION
## Summary
This PR adds comprehensive serialization and deserialization support for macros in modelx. Macros can now be persisted to disk when writing models and restored when reading them back, supporting both function definition and lambda syntax.

## Key Changes

- **Macro Serialization**: Added `MacroEncoder` class to encode macros as Python source code, writing them to a new `_macros.py` file in the model directory
- **Macro Deserialization**: Implemented `MacroFuncDefParser` and `MacroLambdaAssignParser` to parse macro definitions from `_macros.py` during model reading, supporting both `def` and `lambda` syntax
- **Parser Infrastructure**: Added `MacroParserSelector` to route macro statements to the appropriate parser
- **Model Reader Integration**: Extended `ModelReader._read_model_inner()` to call `parse_macros()` and execute macro creation instructions in the correct order
- **Formula Enhancement**: Updated `Formula` initialization to accept an optional `name` parameter for better source tracking
- **Macro Implementation**: Modified `MacroImpl.__init__()` and `set_formula()` to pass macro name to Formula constructor

## Implementation Details

- Macros are only serialized if the model contains them (no empty `_macros.py` file is created)
- The `_macros.py` file includes a pseudo-python header comment to indicate it's modelx-generated code
- Macro parsing respects the same pseudo-python conventions as cells, allowing macros to reference `mx_model` and model names
- Serializer version remains at 7 (no version bump needed)
- Full roundtrip support for both directory and zip-based model storage
- Comprehensive test coverage including function definitions, lambdas, macro chaining, parameter handling, and mixed model content

https://claude.ai/code/session_01NKJw3AFC32PaBP3f9N71mY