### PR TITLE
Update copyright year to 2026

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ by parameterizing *MonteCarlo* with ``r`` and ``sigma``:
 
 License
 -------
-Copyright 2017-2024, Fumito Hamamura
+Copyright 2017-2026, Fumito Hamamura
 
 modelx is free software; you can redistribute it and/or
 modify it under the terms of

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'modelx'
-copyright = '2017-2025, Fumito Hamamura'
+copyright = '2017-2026, Fumito Hamamura'
 author = 'Fumito Hamamura'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/modelx/__init__.py
+++ b/modelx/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/__init__.py
+++ b/modelx/core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/api.py
+++ b/modelx/core/api.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/base.py
+++ b/modelx/core/base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/binding/boundfunc.py
+++ b/modelx/core/binding/boundfunc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation version 3.

--- a/modelx/core/binding/namespace.py
+++ b/modelx/core/binding/namespace.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/cells.py
+++ b/modelx/core/cells.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/chainmap.py
+++ b/modelx/core/chainmap.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/errors.py
+++ b/modelx/core/errors.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/execution/trace.py
+++ b/modelx/core/execution/trace.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/formula.py
+++ b/modelx/core/formula.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/macro.py
+++ b/modelx/core/macro.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/model.py
+++ b/modelx/core/model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/node.py
+++ b/modelx/core/node.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/parent.py
+++ b/modelx/core/parent.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/reference.py
+++ b/modelx/core/reference.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/space.py
+++ b/modelx/core/space.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/system.py
+++ b/modelx/core/system.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/core/util.py
+++ b/modelx/core/util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/export/exporter.py
+++ b/modelx/export/exporter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/export/transformer.py
+++ b/modelx/export/transformer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/io/baseio.py
+++ b/modelx/io/baseio.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/io/excel_legacy.py
+++ b/modelx/io/excel_legacy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/io/excelio.py
+++ b/modelx/io/excelio.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/io/moduleio.py
+++ b/modelx/io/moduleio.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/io/pandas.py
+++ b/modelx/io/pandas.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/io/pandasio.py
+++ b/modelx/io/pandasio.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/serialize/jsonvalues.py
+++ b/modelx/serialize/jsonvalues.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/serialize/serializer_1.py
+++ b/modelx/serialize/serializer_1.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/serialize/serializer_2.py
+++ b/modelx/serialize/serializer_2.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/serialize/serializer_3.py
+++ b/modelx/serialize/serializer_3.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/serialize/serializer_4.py
+++ b/modelx/serialize/serializer_4.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/serialize/serializer_5.py
+++ b/modelx/serialize/serializer_5.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/serialize/serializer_6.py
+++ b/modelx/serialize/serializer_6.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/modelx/serialize/ziputil.py
+++ b/modelx/serialize/ziputil.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 Fumito Hamamura <fumito.ham@gmail.com>
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
 
 # This library is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
## Summary
Update copyright year from 2025 to 2026 across the project documentation and source code.

## Changes
- Updated copyright year in README.rst from 2017-2025 to 2017-2026
- Updated copyright year in documentation configuration (doc/source/conf.py) from 2017-2025 to 2017-2026
- Updated copyright year in all Python source files across the following modules:
  - Core module files (api.py, base.py, cells.py, chainmap.py, errors.py, formula.py, macro.py, model.py, node.py, parent.py, reference.py, space.py, system.py, util.py)
  - Binding module files (boundfunc.py, namespace.py)
  - Execution module files (trace.py)
  - Export module files (exporter.py, transformer.py)
  - IO module files (baseio.py, excel_legacy.py, excelio.py, moduleio.py, pandas.py, pandasio.py)
  - Serialization module files (jsonvalues.py, serializer_1.py through serializer_6.py, ziputil.py)

All copyright headers now reflect 2017-2026 instead of 2017-2025.

https://claude.ai/code/session_017axFtPTSXA9Weqxo26kwiS