### PR TITLE
Add Python 3.14 to supported classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13'
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14'
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
## Summary
Updated the package metadata to indicate support for Python 3.14.

## Changes
- Added `'Programming Language :: Python :: 3.14'` to the classifiers list in setup.py

## Details
This change updates the package's PyPI classifiers to reflect compatibility with Python 3.14, allowing the package to be properly categorized and discovered for users of that Python version.

https://claude.ai/code/session_01AyKZhxheSyHrAs5nVbML32