### PR TITLE
DOC: Add release notes for modelx v0.31.0

### DIFF
--- a/doc/source/releases/relnotes_v0_31_0.rst
+++ b/doc/source/releases/relnotes_v0_31_0.rst
@@ -1,0 +1,58 @@
+====================================
+modelx v0.31.0 (17 May 2026)
+====================================
+
+This release introduces the following enhancements, backward-incompatible
+changes and bug fixes.
+
+To update modelx to the latest version, use the following command::
+
+    >>> pip install modelx --upgrade
+
+Anaconda users should use the ``conda`` command instead::
+
+    >>> conda update modelx
+
+
+Enhancements
+==============
+
+* Macros are now saved and loaded together with the model by
+  :func:`~modelx.write_model` and :func:`~modelx.read_model` (`GH229`_).
+* A pseudo-Python header is now added to serialized Python files for better
+  editor and IDE integration (`GH217`_).
+
+.. _GH229: https://github.com/fumitoh/modelx/pull/229
+.. _GH217: https://github.com/fumitoh/modelx/pull/217
+
+
+Backward Incompatible Changes
+==============================
+
+* This release introduces a new version of the model serializer (serializer
+  version 7). Models saved by this version of modelx **cannot be read by
+  previous versions of modelx**. To save a model in a format that earlier
+  versions (modelx v0.30.x and before) can read, pass ``version=6`` to
+  :func:`~modelx.write_model` or :func:`~modelx.zip_model`::
+
+      >>> modelx.write_model(model, "model_dir", version=6)
+
+
+Bug Fixes
+============
+
+* Docstrings containing special characters (backslashes, embedded or trailing
+  quotes) now round-trip correctly during serialization (`GH228`_).
+* :attr:`~modelx.core.cells.Cells.preds`,
+  :attr:`~modelx.core.cells.Cells.succs` and
+  :attr:`~modelx.core.cells.Cells.precedents` now raise a clear ``ValueError``
+  instead of an internal ``NetworkXError`` when no value is cached for the
+  given arguments.
+* :func:`~modelx.read_model` now raises a clear error when the given path is
+  not a modelx model, instead of a confusing ``FileNotFoundError``.
+* Fixed a crash in the exporter when spaces inherit model-level (global)
+  references.
+* Fixed a crash when formatting formula errors for uncached cells called with
+  unhashable arguments.
+
+.. _GH228: https://github.com/fumitoh/modelx/pull/228

--- a/doc/source/updates.rst
+++ b/doc/source/updates.rst
@@ -12,6 +12,9 @@ Updates
     Visit <a href="https://github.com/fumitoh/modelx/discussions" target="_blank">Discussions</a>
     for more frequent updates.</p>
 
+* *17 May 2026:*
+  modelx v0.31.0 is released. See :doc:`releases/relnotes_v0_31_0`.
+
 * *25 January 2026:*
   spyder-modelx v0.15.0 is released. See :ref:`release-mxplugin-v0.15.0`.
 

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -37,6 +37,7 @@ Release Notes - modelx
 .. toctree::
    :maxdepth: 1
 
+   releases/relnotes_v0_31_0
    releases/relnotes_v0_30_1
    releases/relnotes_v0_30_0
    releases/relnotes_v0_29_2


### PR DESCRIPTION
## Summary

Adds the release notes for the upcoming **modelx v0.31.0** and wires them into the documentation index.

- New `doc/source/releases/relnotes_v0_31_0.rst` (17 May 2026), covering:
  - **Enhancements:** macro serialization support (#229), pseudo-Python header in serialized files (#217)
  - **Backward Incompatible Changes:** new serializer version 7 — models saved by v0.31.0 cannot be read by earlier modelx versions; documents the `version=6` workaround via `modelx.write_model` / `modelx.zip_model`
  - **Bug Fixes:** docstring special-character serialization (#228), clearer errors from `preds`/`succs`/`precedents` and `read_model`, exporter crash on model-level references, and the unhashable-args formatting crash
- Added `releases/relnotes_v0_31_0` to the toctree in `whatsnew.rst`
- Added the v0.31.0 release line to `updates.rst`

## Notes for reviewers

- Version number (0.31.0) confirmed from the serializer map `(0, 31, 0): 7` in `modelx/serialize/__init__.py`. The version in `modelx/__init__.py` is **not** bumped in this PR (out of scope — release notes only).
- The release notes document `version=6` on `modelx.write_model` / `modelx.zip_model`. `Model.write` does **not** currently accept a `version` argument, so it is intentionally not referenced.
- Sphinx HTML build (spy60 env) succeeds with no warnings on the new file. The 3 remaining build warnings are pre-existing orphaned tutorial stubs, untouched here.

## Test plan

- [ ] `cd doc && sphinx -b html source build/html` builds without warnings on `relnotes_v0_31_0`
- [ ] What's New page shows v0.31.0 at the top of the release list and links correctly
- [ ] Latest Updates shows the 17 May 2026 v0.31.0 line

🤖 Generated with [Claude Code](https://claude.com/claude-code)