### PR TITLE
Bump version to 0.31.0

### DIFF
--- a/modelx/__init__.py
+++ b/modelx/__init__.py
@@ -20,7 +20,7 @@ Attributes:
 
 """
 
-VERSION = (0, 30, 1)
+VERSION = (0, 31, 0)
 __version__ = ".".join([str(x) for x in VERSION])
 from modelx.core.api import *  # must come after __version__ assignment.
 try:


### PR DESCRIPTION
## Summary
This pull request updates the version number for the modelx package from 0.30.1 to 0.31.0, indicating a minor version release.

## Changes
- Updated `VERSION` tuple in `modelx/__init__.py` from `(0, 30, 1)` to `(0, 31, 0)`
- The `__version__` string is automatically derived from the VERSION tuple and will now reflect "0.31.0"

## Notes
This is a standard version bump for a minor release. The version change will be reflected in package metadata and distribution.

https://claude.ai/code/session_01BP4BYvrEDFKen9P6RDoHjC