### PR TITLE
Add Python 3.8 and NetworkX 2.5 test matrix to CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,6 +31,8 @@ jobs:
             os: "macos-latest"
           - python-version: {py: "3.7", nx: "2.4"}
             os: "ubuntu-latest"
+          - python-version: {py: "3.8", nx: "2.5"}
+            os: "macos-latest"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version.py }}


### PR DESCRIPTION
## Summary
This PR extends the CI test matrix to include an additional Python and NetworkX version combination to improve test coverage.

## Key Changes
- Added a new test configuration for Python 3.8 with NetworkX 2.5 on macOS
- This complements the existing test matrix which previously covered Python 3.7 with NetworkX 2.4 on Ubuntu

## Details
The new test matrix entry ensures that the codebase is validated against Python 3.8 and NetworkX 2.5, helping to catch any compatibility issues with these versions early. This runs on macOS to provide cross-platform coverage alongside the existing Ubuntu-based tests.

https://claude.ai/code/session_01CyThYQg3aiTNGciruDmzZL