### PR TITLE
TST: Add export test for TradLife_A_EX1 risk margin

### DIFF
--- a/modelx/tests/export/test_lifelib.py
+++ b/modelx/tests/export/test_lifelib.py
@@ -1,4 +1,5 @@
 import importlib
+import shutil
 import sys
 import math
 
@@ -78,6 +79,34 @@ def test_appliedlife(tmp_path_factory):
             nomx.Run[1].GMXB.result_sample()
         )
 
+    finally:
+        sys.path.pop(0)
+        model.close()
+
+
+def test_annuallife(tmp_path_factory):
+    import lifelib
+    library, name = 'annuallife', 'TradLife_A_EX1'
+
+    tmp = tmp_path_factory.mktemp('tmp') / library
+    lifelib.create(library, tmp)
+
+    model = mx.read_model(tmp / name)
+    nomx_path = tmp_path_factory.mktemp('nomx_models')
+    model.export(nomx_path / (name + '_nomx'))
+
+    # The model reads input.xlsx from its parent directory at run time,
+    # so the exported model needs a copy next to it as well.
+    shutil.copy(tmp / 'input.xlsx', nomx_path / 'input.xlsx')
+
+    try:
+        sys.path.insert(0, str(nomx_path))
+        nomx = importlib.import_module(name + '_nomx').mx_model
+        for i in (0, 299):
+            assert math.isclose(
+                model.Projection[i].risk_margin(0),
+                nomx.Projection[i].risk_margin(0)
+            )
     finally:
         sys.path.pop(0)
         model.close()

--- a/modelx/tests/export/test_lifelib.py
+++ b/modelx/tests/export/test_lifelib.py
@@ -92,15 +92,16 @@ def test_annuallife(tmp_path_factory):
     lifelib.create(library, tmp)
 
     model = mx.read_model(tmp / name)
-    nomx_path = tmp_path_factory.mktemp('nomx_models')
-    model.export(nomx_path / (name + '_nomx'))
 
-    # The model reads input.xlsx from its parent directory at run time,
-    # so the exported model needs a copy next to it as well.
-    shutil.copy(tmp / 'input.xlsx', nomx_path / 'input.xlsx')
+    # Export next to the source model so that input.xlsx, which the model
+    # reads from its parent directory at run time, is found by the exported
+    # model as well. Remove a bundled copy of the exported model if any.
+    nomx_dir = tmp / (name + '_nomx')
+    shutil.rmtree(nomx_dir, ignore_errors=True)
+    model.export(nomx_dir)
 
     try:
-        sys.path.insert(0, str(nomx_path))
+        sys.path.insert(0, str(tmp))
         nomx = importlib.import_module(name + '_nomx').mx_model
         for i in (0, 299):
             assert math.isclose(


### PR DESCRIPTION
## What

Adds `test_annuallife` to `modelx/tests/export/test_lifelib.py`, testing the exported (nomx) model of lifelib's `annuallife/TradLife_A_EX1` against the source modelx model. The test asserts that `Projection[i].risk_margin(0)` agrees between the two for model points `i = 0` and `i = 299`.

## Why

`TradLife_A_EX1` exercises nested projections (`InnerProj` ItemSpaces under prescribed life stresses at each projection step), which were not previously covered by the export tests.

## Notes for review

- The model reads `input.xlsx` from its parent directory at run time (`_model.path.parent / input_file_name`), and the exporter does not bake the workbook in. The test therefore exports the nomx model into the same directory as the source model, so both resolve the same workbook.
- A `TradLife_A_EX1_nomx` directory bundled with the copied library, if present, is removed before exporting, since the exporter overwrites files but does not clear a pre-existing target directory.
- Requires a lifelib version that includes the `annuallife` library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)