### PR TITLE
MAINT: Drop Python 3.7/3.8 from CI matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,9 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [{py: "3.7", nx: "2.4"},
-                         {py: "3.8", nx: "2.5"},
-                         {py: "3.9", nx: "2.6"},
+        python-version: [{py: "3.9", nx: "2.6"},
                          {py: "3.10", nx: "2.7"},
                          {py: "3.11", nx: "2.8"},
                          {py: "3.12", nx: "3.2"},
@@ -26,13 +24,6 @@ jobs:
                          {py: "3.14", nx: "3.5"}
         ]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        exclude:
-          - python-version: {py: "3.7", nx: "2.4"}
-            os: "macos-latest"
-          - python-version: {py: "3.7", nx: "2.4"}
-            os: "ubuntu-latest"
-          - python-version: {py: "3.8", nx: "2.5"}
-            os: "macos-latest"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version.py }}


### PR DESCRIPTION
## What

Removes Python 3.7 and 3.8 (and their paired networkx versions 2.4/2.5) from the CI test matrix, along with the per-OS excludes that only applied to them.

## Why

The 3.7/3.8 jobs now fail in the "Install dependencies" step, before any tests run. `requirements-travis.txt` installs lifelib from its GitHub main branch, and lifelib v0.13.0 (June 28) dropped Python 3.7/3.8 support (`python_requires >= 3.9`). On those interpreters pip can no longer resolve the requirement set: it backtracks numpy down to 1.16.x sdists on 3.8 (`ModuleNotFoundError: No module named 'distutils.msvccompiler'`) and an old pandas sdist on 3.7 (invalid metadata for modern setuptools).

Both versions are past end of life (3.7 since June 2023, 3.8 since October 2024). This continues the cleanup started in 0f39301, which excluded Python 3.8 on macos-latest.

## Notes for review

- This unblocks #239, which currently shows the same three job failures.
- This changes only what CI tests. If modelx itself should stop claiming 3.7/3.8 support (`python_requires`, trove classifiers in setup.py), that can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
