### PR TITLE
MAINT: Remove namespace self-observation (D-12, Phase 2)

### DIFF
--- a/modelx/core/binding/boundfunc.py
+++ b/modelx/core/binding/boundfunc.py
@@ -59,17 +59,26 @@ class AlteredFunction(BaseNamespaceReferrer):
     _global_names: tuple
     _altfunc: FunctionType
 
-    def __init__(self, server):
+    def __init__(self, server, observe=True):
         """Create altered function from owner's formula.
 
         owner is a UserSpaceImpl or CellsImpl, which has formula, and
         namespace_impl as its members.
         """
-        BaseNamespaceReferrer.__init__(self, server)
+        BaseNamespaceReferrer.__init__(self, server, observe=observe)
         self.is_altfunc_updated = False
         self._is_global_updated = False
 
     def on_notify(self, subject: Subject):
+        self.on_ns_invalidated()
+
+    def on_ns_invalidated(self):
+        """Invalidate namespace-dependent caches.
+
+        Called directly by NamespaceServer.on_notify when self is the
+        server (spaces), or via on_notify when observing a separate
+        server (cells).
+        """
         self.is_altfunc_updated = False
         self._is_global_updated = False
 

--- a/modelx/core/binding/namespace.py
+++ b/modelx/core/binding/namespace.py
@@ -54,6 +54,12 @@ class NamespaceServer(Subject):
 
     def on_notify(self, subject: Subject) -> None:
         self._is_ns_updated = False
+        # Invalidate this object's own namespace-dependent caches through a
+        # direct hook instead of having the object observe itself.
+        # NamespaceServer deliberately does not define on_ns_invalidated:
+        # it precedes AlteredFunction in BaseSpaceImpl's MRO, so defining a
+        # default here would shadow AlteredFunction's implementation.
+        self.on_ns_invalidated()
         self.notify()   # notify observers
 
     @property
@@ -89,8 +95,11 @@ class BaseNamespaceReferrer(Observer):
     
     ns_server: NamespaceServer
 
-    def __init__(self, server: NamespaceServer):
-        Observer.__init__(self, (server,))
+    def __init__(self, server: NamespaceServer, observe: bool = True):
+        # observe=False initializes state without registering as an observer;
+        # used when self IS the server (NamespaceServer.on_notify invalidates
+        # its own caches via on_ns_invalidated instead).
+        Observer.__init__(self, (server,) if observe else ())
         self.ns_server = server
 
     def on_notify(self, namspace: NamespaceServer):

--- a/modelx/core/space.py
+++ b/modelx/core/space.py
@@ -1984,7 +1984,10 @@ class BaseSpaceImpl(*_base_space_impl_base):
         )
 
         ItemSpaceParent.__init__(self, formula)
-        AlteredFunction.__init__(self, self)
+        # observe=False: the space is its own namespace server; its caches
+        # are invalidated via the direct on_ns_invalidated hook (D-12)
+        # instead of the space observing itself.
+        AlteredFunction.__init__(self, self, observe=False)
 
         container[name] = self
 
@@ -1996,13 +1999,6 @@ class BaseSpaceImpl(*_base_space_impl_base):
                 self.own_refs[key] = ReferenceImpl(self, key, value, container=self.own_refs,
                               refmode="auto", set_item=False)
 
-
-    def on_notify(self, subject):
-        if subject is self.ns_server:
-            assert subject is self
-            AlteredFunction.on_notify(self, subject)
-        else:
-            NamespaceServer.on_notify(self, subject)
 
     def on_update_ns(self):
         for k, v in self.named_spaces.items():
@@ -2027,6 +2023,10 @@ class BaseSpaceImpl(*_base_space_impl_base):
     def __setstate__(self, state):
         for k, v in state.items():
             setattr(self, k, v)
+        # Pickles from versions before the self-observation removal (D-12)
+        # contain the space in its own observer list; with the identity
+        # dispatch gone, that edge would recurse infinitely on notify.
+        self.observers = [obs for obs in self.observers if obs is not self]
         self.dynamic_cache = weakref.WeakValueDictionary()
 
     def _init_refs(self, arguments=None):

--- a/modelx/tests/core/binding/test_namespace.py
+++ b/modelx/tests/core/binding/test_namespace.py
@@ -1,6 +1,49 @@
 import modelx as mx
 
 
+def test_space_not_self_observer():
+    """D-12 (Phase 2): a space no longer registers in its own observer list.
+
+    The space's own namespace-dependent caches are invalidated through
+    the direct on_ns_invalidated hook in NamespaceServer.on_notify instead.
+    """
+    m = mx.new_model()
+    s = m.new_space("Space1")
+    impl = s._impl
+    assert all(obs is not impl for obs in impl.observers)
+
+    m._impl._check_sanity()
+    m.close()
+
+
+def test_direct_hook_invalidates_space_formula():
+    """A ref change rebinds the space's own (param) formula via the hook."""
+    m = mx.new_model()
+    s = m.new_space("Space1", formula=lambda i: {"refs": {"y": x * i}})
+    s.x = 2
+    assert s[3].y == 6
+    s.x = 5
+    assert s[3].y == 15
+
+    m._impl._check_sanity()
+    m.close()
+
+
+def test_setstate_strips_self_observation():
+    """Unpickled state saved before D-12 drops the self-observation edge.
+
+    Without this, notifying a space restored from an old runtime pickle
+    would recurse infinitely (the identity dispatch that used to absorb
+    the self-edge is gone).
+    """
+    from modelx.core.space import UserSpaceImpl
+
+    obj = UserSpaceImpl.__new__(UserSpaceImpl)
+    other = object()
+    obj.__setstate__({"observers": [obj, other]})
+    assert obj.observers == [other]
+
+
 def test_namespace_in_fromula():
     m = mx.new_model()
     s = m.new_space("Space1")


### PR DESCRIPTION
## What

Phase 2 of the core refactoring roadmap (`devnotes/CoreRefactorDesign.md`, D-12): spaces no longer register themselves in their own observer lists. Behavior is intended to be identical — this removes a re-entrant notification edge before the pipeline phases (4+) build on notification.

- `NamespaceServer.on_notify` now invalidates the object''s own namespace-dependent caches via a direct hook `self.on_ns_invalidated()` (after clearing `_is_ns_updated`, before `notify()`), replacing the identity dispatch that `BaseSpaceImpl.on_notify` used to absorb the self-observation edge.
- `AlteredFunction` implements `on_ns_invalidated` (clears `is_altfunc_updated` / `_is_global_updated`); its `on_notify` delegates to it, so cells observing their parent space are unchanged.
- `BaseNamespaceReferrer.__init__` / `AlteredFunction.__init__` gain an `observe=True` parameter, splitting state initialization from observer registration; `BaseSpaceImpl.__init__` passes `observe=False`.
- The identity-dispatch `BaseSpaceImpl.on_notify` is deleted; lookup falls through the MRO to `NamespaceServer.on_notify` (base order is `(NamespaceServer, ItemSpaceParent, BaseParentImpl, Impl)`). `DynamicBase.on_notify` is untouched (Phase 4 territory) and its internal `BaseSpaceImpl.on_notify(self, subject)` call resolves correctly.
- `BaseSpaceImpl.__setstate__` strips the self-observation edge from runtime pickles saved by earlier versions — with the identity dispatch gone, that stale edge would recurse infinitely on notify.
- Three regression tests added in `modelx/tests/core/binding/test_namespace.py`: the no-self-observer invariant, end-to-end invalidation of a space''s own param formula through the new hook, and the `__setstate__` guard.

## Notes for review

- `NamespaceServer` deliberately does **not** define a default `on_ns_invalidated`: it precedes `AlteredFunction` in `BaseSpaceImpl`''s MRO, so a default there would shadow the real implementation. There''s a comment at the call site explaining this.
- Ordering is preserved: the space''s own altfunc flags were previously cleared first because the space was the first-registered observer; the direct hook runs at exactly that point, before other observers are notified.
- Pre-existing, unrelated: runtime pickling of live models (`pickle.dumps(model)`) is already broken on master (`__getstate__` reads lazily-assigned slots `_global_names`/`_altfunc`; a materialized `_altfunc` is an unpicklable dynamic function). Confirmed identical on clean master; tracked separately.

## Testing

- Full suite: `pytest modelx/tests` — **1051 passed, 6 skipped, 3 xfailed** (the strict xfails are the Phase 0 rollback characterization tests that Phase 6 flips).
- Design-doc sensitive suites pass: `tests/core/binding/`, `tests/core/reference/`, `tests/performance/`.
- A 4-lens adversarial review (MRO/dispatch resolution, observer/call-site sweep, behavioral-ordering equivalence, design conformance + pickle) found zero defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)