### PR TITLE
MAINT: Replace ReferenceManager with ValueRegistry (Phase 3)

### DIFF
--- a/modelx/core/model.py
+++ b/modelx/core/model.py
@@ -57,7 +57,7 @@ from modelx.core.inheritance.manager import (
     SpaceUpdater,
 )
 from modelx.core.edit.transaction import Instruction, InstructionList
-from modelx.core.refs import ReferenceManager
+from modelx.core.refs import ValueRegistry, ReferenceManager
 
 
 class IOSpecOperation:
@@ -107,7 +107,7 @@ class IOSpecOperation:
             * :class:`~modelx.io.pandasio.PandasData`: IOSpec for pandas objects
 
         """
-        return self._impl.model.refmgr.update_value(old_data, new_data)
+        return self._impl.model.valreg.update_value(old_data, new_data)
 
     def update_module(self, old_module, new_module=None):
         """Update an user-defined module assigned to References
@@ -148,7 +148,7 @@ class IOSpecOperation:
         """
         if not isinstance(old_module, ModuleType):
             raise ValueError("not a module object")
-        return self._impl.model.refmgr.update_value(old_module, new_module)
+        return self._impl.model.valreg.update_value(old_module, new_module)
 
     def get_spec(self, data):
         """Get *IOSpec* associated with ``data``
@@ -164,7 +164,7 @@ class IOSpecOperation:
             * :class:`~modelx.io.baseio.BaseIOSpec`: Base class for IOSpec objects
             * :attr:`~modelx.core.model.Model.iospecs`: List all IOSpecs
         """
-        spec = self._impl.refmgr.get_spec(data)
+        spec = self._impl.valreg.get_spec(data)
         if spec is None:
             raise ValueError("spec not found")
         else:
@@ -183,7 +183,7 @@ class IOSpecOperation:
             * :class:`~modelx.io.baseio.BaseIOSpec`: Base class for IOSpec objects
             * :attr:`~modelx.core.model.Model.iospecs`: List all IOSpecs
         """
-        self._impl.refmgr._manager.del_spec(self.get_spec(data))
+        self._impl.valreg._manager.del_spec(self.get_spec(data))
 
     @property
     def iospecs(self):
@@ -224,7 +224,7 @@ class IOSpecOperation:
         .. versionadded:: 0.9.0
 
         """
-        return list(self._impl.refmgr.specs)
+        return list(self._impl.valreg.specs)
 
 
 class Model(IOSpecOperation, EditableParent):
@@ -662,21 +662,21 @@ class Model(IOSpecOperation, EditableParent):
 
     def _get_refs(self, value):
         """Get references referring to a value"""
-        refs = self._impl.refmgr._valid_to_refs[id(value)]
+        refs = self._impl.valreg.get_refs(value)
         return [ReferenceProxy(impl) for impl in refs]
 
     def _get_assoc_values(self):
         """Get a list of values in the model with their associates"""
         result = []
 
-        for valid, refs in self._impl.refmgr._valid_to_refs.items():
+        for value in self._impl.valreg.values:
             info = {}
-            info["value"] = refs[0].interface
+            info["value"] = value
             info["spec"] = self._impl.system.iomanager.get_spec_from_value(
                 io_group=self,
-                value=refs[0].interface
+                value=value
             )
-            info["refs"] = self._get_refs(info["value"])
+            info["refs"] = self._get_refs(value)
             result.append(info)
 
         return result
@@ -1189,7 +1189,7 @@ class ModelImpl(*_model_impl_base):
         "_macro_namespace",
         "currentspace",
         "path",
-        "refmgr"
+        "valreg"
     ) + get_mixin_slots(*_model_impl_base)
 
     def __init__(self, *, system, name):
@@ -1219,7 +1219,7 @@ class ModelImpl(*_model_impl_base):
         self._namespace = CustomChainMap(self.named_spaces, self._global_refs)
         self.namespace = ModelNamespace(self)
         self.allow_none = False
-        self.refmgr = ReferenceManager(self, system.iomanager)
+        self.valreg = ValueRegistry(self, system.iomanager)
 
     def rename(self, name):
         """Rename self. Must be called only by its system."""
@@ -1266,10 +1266,15 @@ class ModelImpl(*_model_impl_base):
 
         for name, r in self.global_refs.items():
             if name != "__builtins__":
-                assert id(r.interface) in self.refmgr._valid_to_refs
+                assert self.valreg.has_value(r.interface)
 
-        self.refmgr._check_sanity()
+        self.valreg._check_sanity()
         self.spmgr._check_sanity()
+
+    @property
+    def refmgr(self):
+        """Backward-compat alias for :attr:`valreg` (D-10)."""
+        return self.valreg
 
     @property
     def updater(self):
@@ -1314,9 +1319,12 @@ class ModelImpl(*_model_impl_base):
         elif name in self._macros:
             raise KeyError("Macro named '%s' already exists" % name)
         elif name in self.global_refs:
-            self.refmgr.change_ref(self, name, value)
+            prev_ref = self.global_refs[name]
+            self.change_ref(name, value)
+            self.valreg.rebind(prev_ref, self.global_refs[name])
         else:
-            self.refmgr.new_ref(self, name, value, refmode)
+            ref = self.new_ref(name, value)
+            self.valreg.register(ref)
 
     def del_attr(self, name):
 
@@ -1325,9 +1333,16 @@ class ModelImpl(*_model_impl_base):
         elif name in self._macros:
             self.del_macro(name)
         elif name in self.global_refs:
-            self.refmgr.del_ref(self, name)
+            ref = self.global_refs[name]
+            self.del_ref(name)
+            self.valreg.unregister(ref)
         else:
             raise KeyError("Name '%s' not defined" % name)
+
+    def on_update_ref(self, name, value, refmode):
+        """Rebind a global ref for ValueRegistry.update_value."""
+        self.change_ref(name, value)
+        return self.global_refs[name]
     
     # Macro methods
     

--- a/modelx/core/refs.py
+++ b/modelx/core/refs.py
@@ -13,133 +13,162 @@
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 from modelx.core.base import Interface
-from modelx.core.space import UserSpaceImpl
 
 
-class ReferenceManager:
+class _ValueEntry:
+    """Registry entry for one referenced value.
+
+    Holds the value itself strongly, so its id cannot be reused by
+    another object while the entry exists (D-4).
+    """
+
+    __slots__ = ("value", "refs")
+
+    def __init__(self, value, refs):
+        self.value = value
+        self.refs = refs        # [ReferenceImpl]
+
+
+class ValueRegistry:
+    """Tracks non-Interface values assigned to References (Phase 3).
+
+    Successor to ``ReferenceManager``. The ``register``/``unregister``/
+    ``rebind`` hooks below are pure bookkeeping: the callers
+    (``ModelImpl.set_attr``/``del_attr``, ``UserSpaceImpl.set_attr``/
+    ``del_ref``) invoke the spmgr/ModelImpl mutators directly and then
+    the hooks. The one remaining mutation path is ``update_value``,
+    which rebinds refs through ``parent.on_update_ref``; it is slated
+    to become an Edit in Phase 4.
+
+    Only refs assigned through those attribute-access paths are
+    registered; derived refs and refs created by
+    ``new_space(refs=...)`` are not, matching ReferenceManager.
+    The IOSpec associated with a value is garbage-collected exactly
+    when the value's last registered ref disappears.
+    """
 
     def __init__(self, model, iomanager):
         self._model = model
         self._manager = iomanager
-        self._valid_to_refs = {}         # id(value) -> [refs]
+        self._entries = {}          # id(value) -> _ValueEntry
 
-    def _check_sanity(self):
+    # ----------------------------------------------------------------------
+    # Registry hooks called after model mutation
 
-        for refs in self._valid_to_refs.values():
-            for r in refs:
-                spec = self._manager.get_spec_from_value(
-                    io_group=self._model.interface,
-                    value=r.interface)
-                if spec is not None:
-                    assert r.interface is spec.value
-                    spec._check_sanity()
+    def register(self, ref):
+        """Add ``ref`` to the entry of its value."""
+        value = ref.interface
+        if isinstance(value, Interface):
+            return
+        entry = self._entries.get(id(value))
+        if entry is None:
+            self._entries[id(value)] = _ValueEntry(value, [ref])
+        else:
+            assert all(ref is not r for r in entry.refs)
+            entry.refs.append(ref)
+
+    def unregister(self, ref):
+        """Remove ``ref``; GC the value's spec when its last ref goes."""
+        value = ref.interface
+        if isinstance(value, Interface):
+            return
+        entry = self._entries.get(id(value))
+        assert entry
+        entry.refs.remove(ref)
+        if not entry.refs:
+            del self._entries[id(value)]
+            self._del_spec_if_any(value)
+
+    def rebind(self, old_ref, new_ref):
+        """Move registration from ``old_ref`` to ``new_ref``.
+
+        Tolerates ``old_ref`` not being registered (e.g. it is derived,
+        or was created by ``new_space(refs=...)``), unlike
+        ``unregister``.
+        """
+        old_value = old_ref.interface
+        entry = self._entries.get(id(old_value))
+        if entry is not None:
+            if old_ref in entry.refs:
+                entry.refs.remove(old_ref)
+            if not entry.refs:
+                del self._entries[id(old_value)]
+                self._del_spec_if_any(old_value)
+
+        new_value = new_ref.interface
+        if not isinstance(new_value, Interface):
+            entry = self._entries.get(id(new_value))
+            if entry is None:
+                self._entries[id(new_value)] = _ValueEntry(
+                    new_value, [new_ref])
+            else:
+                entry.refs.append(new_ref)
+
+    # ----------------------------------------------------------------------
+    # Queries
+
+    def has_value(self, value):
+        return id(value) in self._entries
+
+    def get_refs(self, value):
+        """Return a list of the refs registered for ``value``."""
+        return list(self._entries[id(value)].refs)
+
+    @property
+    def values(self):
+        return list(entry.value for entry in self._entries.values())
+
+    @property
+    def _valid_to_refs(self):
+        """Backward-compat view: id(value) -> [refs].
+
+        The lists are the live entry lists; the dict itself is built on
+        each access.
+        """
+        return {valid: entry.refs
+                for valid, entry in self._entries.items()}
+
+    # ----------------------------------------------------------------------
+    # IOSpec bookkeeping
 
     def has_spec(self, value):
-        spec = self._manager.get_spec_from_value(self._model.interface, value)
-        return spec is not None
+        return self.get_spec(value) is not None
 
     def get_spec(self, value):
         return self._manager.get_spec_from_value(self._model.interface, value)
 
     @property
-    def values(self):
-        return list(ref[0].interface for ref in self._valid_to_refs.values())
-
-    @property
     def specs(self):
         result = []
-        for r in self._valid_to_refs.values():
-            spec = self.get_spec(r[0].interface)
+        for entry in self._entries.values():
+            spec = self.get_spec(entry.value)
             if spec is not None:
                 result.append(spec)
         return result
-
-    def new_ref(self, impl, name, value, refmode):
-        # ModelImpl imported here to avoid a circular import with model.py
-        from modelx.core.model import ModelImpl
-
-        if isinstance(impl, ModelImpl):
-            ref = impl.new_ref(name, value)
-        elif isinstance(impl, UserSpaceImpl):
-            ref = impl.model.spmgr.new_ref(impl, name, value, refmode)
-        else:
-            raise RuntimeError("must not happen")
-
-        if not isinstance(value, Interface):
-            refs = self._valid_to_refs.setdefault(id(value), [])
-            assert all(ref is not r for r in refs)
-            refs.append(ref)
-
-    def del_ref(self, impl, name):
-        # ModelImpl imported here to avoid a circular import with model.py
-        from modelx.core.model import ModelImpl
-
-        refdict = impl.own_refs
-        ref = refdict[name]
-        valid = id(ref.interface)
-        val = ref.interface
-
-        if isinstance(impl, ModelImpl):
-            impl.del_ref(name)
-        elif isinstance(impl, UserSpaceImpl):
-            impl.model.spmgr.del_ref(impl, name)
-        else:
-            raise RuntimeError("must not happen")
-
-        if not isinstance(val, Interface):
-            refs = self._valid_to_refs.get(valid)
-            assert refs
-            refs.remove(ref)
-            if not refs:
-                del self._valid_to_refs[valid]
-                spec = self._manager.get_spec_from_value(
-                    io_group=self._model.interface,
-                    value=val
-                )
-                if spec:
-                    self._manager.del_spec(spec)
-
-    def change_ref(self, impl, name, value, refmode=None):
-        # ModelImpl imported here to avoid a circular import with model.py
-        from modelx.core.model import ModelImpl
-
-        refdict = impl.own_refs
-        prev_ref = refdict[name]
-        prev_valid = id(prev_ref.interface)
-        prev_val = prev_ref.interface
-
-        if isinstance(impl, ModelImpl):
-            impl.model.change_ref(name, value)
-        elif isinstance(impl, UserSpaceImpl):
-            impl.model.spmgr.change_ref(impl, name, value, refmode)
-        else:
-            raise RuntimeError("must not happen")
-
-        refs = self._valid_to_refs.get(prev_valid, None)
-        if refs is not None:        # None in case prev_ref is derived
-            if prev_ref in refs:
-                refs.remove(prev_ref)
-            if not refs:    # ref is empty
-                del self._valid_to_refs[prev_valid]
-                spec = self._manager.get_spec_from_value(self._model.interface, prev_val)
-                if spec:
-                    self._manager.del_spec(spec)
-
-        if not isinstance(value, Interface):
-            self._valid_to_refs.setdefault(id(value), []).append(refdict[name])
 
     def del_all_spec(self):
         specs = self.specs.copy()
         while specs:
             self._manager.del_spec(specs.pop())
 
+    def _del_spec_if_any(self, value):
+        spec = self._manager.get_spec_from_value(
+            io_group=self._model.interface,
+            value=value
+        )
+        if spec:
+            self._manager.del_spec(spec)
+
+    # ----------------------------------------------------------------------
+    # Value update
+
     def update_value(self, old_value, new_value=None, **kwargs):
 
-        prev_id = id(old_value)
-        refs = self._valid_to_refs.get(prev_id, None)
-        spec = self._manager.get_spec_from_value(self._model.interface, old_value)
+        entry = self._entries.get(id(old_value))
+        spec = self._manager.get_spec_from_value(
+            self._model.interface, old_value)
 
-        if refs is None:
+        if entry is None:
             raise ValueError("value not referenced")
 
         if new_value is None:
@@ -149,27 +178,35 @@ class ReferenceManager:
             self._manager.update_spec_value(spec, new_value, kwargs)
             new_value = spec.value
 
+        refs = entry.refs
         newrefs = []
         while refs:
             ref = refs.pop()
-            impl = ref.parent
-            name = ref.name
-            refmode = ref.refmode
-            value = new_value
-            self._impl_change_ref(impl, name, value, refmode)
-            newrefs.append(impl.own_refs[name])
+            newrefs.append(
+                ref.parent.on_update_ref(ref.name, new_value, ref.refmode))
 
-        self._valid_to_refs.pop(prev_id)
-        self._valid_to_refs[id(new_value)] = newrefs
+        del self._entries[id(old_value)]
+        self._entries[id(new_value)] = _ValueEntry(new_value, newrefs)
 
-    @staticmethod
-    def _impl_change_ref(impl, name, value, *refmode):
-        # ModelImpl imported here to avoid a circular import with model.py
-        from modelx.core.model import ModelImpl
+    # ----------------------------------------------------------------------
+    # Sanity check
 
-        if isinstance(impl, ModelImpl):
-            impl.model.change_ref(name, value)
-        elif isinstance(impl, UserSpaceImpl):
-            impl.model.spmgr.change_ref(impl, name, value, refmode)
-        else:
-            raise RuntimeError("must not happen")
+    def _check_sanity(self):
+
+        for valid, entry in self._entries.items():
+            assert valid == id(entry.value)
+            assert entry.refs
+            for r in entry.refs:
+                assert r.interface is entry.value
+            spec = self._manager.get_spec_from_value(
+                io_group=self._model.interface,
+                value=entry.value)
+            if spec is not None:
+                assert entry.value is spec.value
+                spec._check_sanity()
+
+
+# Import alias: ReferenceManager was replaced by ValueRegistry in
+# Phase 3 of the core refactoring. Kept for compatibility with code
+# importing the old name.
+ReferenceManager = ValueRegistry

--- a/modelx/core/space.py
+++ b/modelx/core/space.py
@@ -2323,9 +2323,12 @@ class UserSpaceImpl(*_user_space_impl_base):
         if self.get_attr(name) is not None:
             if name in self.refs:
                 if name in self.own_refs:
-                    self.model.refmgr.change_ref(self, name, value, refmode)
+                    prev_ref = self.own_refs[name]
+                    self.model.spmgr.change_ref(self, name, value, refmode)
+                    self.model.valreg.rebind(prev_ref, self.own_refs[name])
                 elif self.refs[name].parent is self.model:
-                    self.model.refmgr.new_ref(self, name, value, refmode)
+                    ref = self.model.spmgr.new_ref(self, name, value, refmode)
+                    self.model.valreg.register(ref)
                 else:
                     raise RuntimeError("must not happen")
 
@@ -2337,7 +2340,8 @@ class UserSpaceImpl(*_user_space_impl_base):
             else:
                 raise ValueError
         else:
-            self.model.refmgr.new_ref(self, name, value, refmode)
+            ref = self.model.spmgr.new_ref(self, name, value, refmode)
+            self.model.valreg.register(ref)
 
     def del_attr(self, name):
         """Implementation of attribute deletion
@@ -2365,7 +2369,9 @@ class UserSpaceImpl(*_user_space_impl_base):
     def del_ref(self, name):
 
         if name in self.own_refs:
-            self.model.refmgr.del_ref(self, name)
+            ref = self.own_refs[name]
+            self.model.spmgr.del_ref(self, name)
+            self.model.valreg.unregister(ref)
         elif name in self.is_derived():
             raise KeyError("Derived ref '%s' cannot be deleted" % name)
         elif name in self.arguments:
@@ -2378,6 +2384,11 @@ class UserSpaceImpl(*_user_space_impl_base):
             )
         else:
             raise KeyError("Ref '%s' does not exist" % name)
+
+    def on_update_ref(self, name, value, refmode):
+        """Rebind an own ref for ValueRegistry.update_value."""
+        self.model.spmgr.change_ref(self, name, value, refmode)
+        return self.own_refs[name]
 
     # ----------------------------------------------------------------------
     # Reloading

--- a/modelx/core/system.py
+++ b/modelx/core/system.py
@@ -234,7 +234,7 @@ class System:
             return m.currentspace
 
     def close_model(self, model):
-        model.refmgr.del_all_spec()
+        model.valreg.del_all_spec()
         del self.models[model.name]
         if self.currentmodel is model:
             self.currentmodel = None


### PR DESCRIPTION
## What

Phase 3 of the core refactoring ([devnotes/CoreRefactorDesign.md](https://github.com/fumitoh/modelx/blob/main/devnotes/CoreRefactorDesign.md) — untracked design doc; see §7 Phase 3): replace `ReferenceManager` with `ValueRegistry` and break the refmgr↔spmgr circularity.

- **`refs.py`**: `ReferenceManager` → `ValueRegistry`. Entries are `_ValueEntry(value, refs)` objects keyed by `id(value)` that hold the value **strongly**, so id reuse is impossible by construction while a value is registered (decision D-4). API: `register`/`unregister` (strict)/`rebind` (tolerant)/`values`/`specs`/`update_value`/`_check_sanity`. The isinstance-dispatch blocks that called back into `spmgr`/`ModelImpl` are deleted; `refs.py` no longer imports `space.py` or `model.py` at all.
- **Dispatch inversion**: `ModelImpl.set_attr`/`del_attr` and `UserSpaceImpl.set_attr`/`del_ref` now call the `ModelImpl`/`spmgr` mutators directly, then the registry hooks.
- **Compat kept**: `model.refmgr` property alias (D-10), `_valid_to_refs` backward-compat property, `ReferenceManager = ValueRegistry` import alias. Phase 0 characterization tests (`test_iospec_refcount.py` etc.) pass **unmodified**.
- **Sanity extended** per design §8(b): every registry entry's value is asserted identical to all its refs' interfaces.

## Bug fix included

`update_value` (backing `Model.update_pandas`/`update_module`) previously corrupted `refmode` into a 1-tuple (e.g. `(False,)` or `("auto",)`) on every rebound ref, via the `*refmode` star-arg in the old `_impl_change_ref`. The new polymorphic `on_update_ref(name, value, refmode)` hook on `ModelImpl`/`UserSpaceImpl` passes `refmode` through unchanged. Verified by probe against main before the rewrite.

## Behavior deliberately preserved

- IOSpec GC ordering is exact: the spec is deleted precisely when the last **registered** ref to a value disappears.
- Deleting a ref that was never registered (e.g. created via `new_space(refs=...)`) still raises `AssertionError`, identical to main; making that path tolerant belongs to Phase 4's pipeline work.
- Refs created by `spmgr.new_ref` directly (derived refs, `new_space(refs=...)`) stay unregistered, as before.

## Verification

- Full suite: **1051 passed, 6 skipped, 3 xfailed** (identical to the pre-change baseline; the 3 xfails are the strict Phase 0 rollback gates that Phase 6 flips).
- Targeted suites from the design doc: `tests/core/reference/**`, `tests/serialize/**`, `tests/io/**` all green.
- A 17-agent adversarial review (behavioral-equivalence, call-site/compat, edge-case, and design-conformance lenses, each finding independently verified against main) surfaced no real defects beyond a docstring fix. Two pre-existing `update_value` warts reproduce identically on main and are left for Phase 4's update_value-as-Edit rework: entry clobbering when the new value is already registered elsewhere, and IOSpec destroy/recreate when reassigning the same object to its sole ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)