### PR TITLE
MAINT: Add edit pipeline for reference mutations (Phase 4)

### DIFF
--- a/modelx/core/cells.py
+++ b/modelx/core/cells.py
@@ -750,12 +750,25 @@ class CellsImpl(*_cells_impl_base):
         else:
             raise ValueError("%s not a scalar" % self.name)
 
-    def on_inherit(self, updater, bases):
-        self.model.clear_obj(self)
-        self.formula = bases[0].formula
-        self.allow_none = bases[0].allow_none
-        self.is_cached = bases[0].is_cached
-        self.is_altfunc_updated = False
+    def on_inherit(self, updater, bases, txn=None):
+        if txn is None:
+            self.model.clear_obj(self)
+            self.formula = bases[0].formula
+            self.allow_none = bases[0].allow_none
+            self.is_cached = bases[0].is_cached
+            self.is_altfunc_updated = False
+        elif (self.formula is not bases[0].formula
+                or self.allow_none != bases[0].allow_none
+                or self.is_cached != bases[0].is_cached):
+            # Journaled writes; clear_obj is deferred to the pipeline
+            # finalize stage and skipped when nothing changed. The
+            # namespace entry (the bound ``call``) is unaffected by an
+            # in-place rebind, so no container is marked dirty.
+            txn.set_attr(self, "formula", bases[0].formula)
+            txn.set_attr(self, "allow_none", bases[0].allow_none)
+            txn.set_attr(self, "is_cached", bases[0].is_cached)
+            txn.set_attr(self, "is_altfunc_updated", False)
+            txn.add_modified(self)
 
     @property
     def doc(self):

--- a/modelx/core/edit/pipeline.py
+++ b/modelx/core/edit/pipeline.py
@@ -1,0 +1,324 @@
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
+
+# This library is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation version 3.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unified mutation pipeline (CoreRefactorDesign §5.4, Phase 4).
+
+One ``ModelEditor`` entry point runs each ``Edit`` through
+validate -> apply -> derive inside a :class:`Transaction`, rolls back on
+any exception, and performs all side effects (trace invalidation,
+deletions, batched namespace notification, ValueRegistry/IOSpec
+bookkeeping, itemspace invalidation) post-commit in ``_finalize``.
+
+Phase 4 covers the reference mutations end-to-end. The ``derive`` stage
+is an interim per-Edit hook: Phase 5 replaces it with
+``InheritanceSync.derive`` as the single home of derived-member
+creation.
+"""
+
+from modelx.core.base import Interface
+from modelx.core.binding.namespace import NamespaceServer
+from modelx.core.reference import ReferenceImpl
+from modelx.core.edit.transaction import Transaction, ChangeSet
+
+
+class Edit:
+    """One model mutation.
+
+    ``validate`` performs name/cycle/relref checks without changing any
+    state; ``apply`` performs the defined-member structural writes,
+    journaled through the transaction; ``derive`` fans the change out to
+    derived members in sub spaces (interim home, see module docstring).
+    """
+
+    result = None
+
+    def validate(self, model, txn):
+        pass
+
+    def apply(self, model, txn):
+        raise NotImplementedError
+
+    def derive(self, model, txn):
+        pass
+
+
+class ModelEditor:
+    """Runs Edits against a model (CoreRefactorDesign §5.4).
+
+    Stateless: constructed per access by ``ModelImpl.editor`` so that no
+    new slot enters pickled model state.
+    """
+
+    def __init__(self, model):
+        self.model = model
+
+    def execute(self, edit):
+        txn = Transaction(self.model)
+        try:
+            edit.validate(self.model, txn)
+            edit.apply(self.model, txn)
+            edit.derive(self.model, txn)
+        except BaseException:
+            txn.rollback()
+            raise
+        txn.commit()
+        self._finalize(txn.changes)
+        return edit.result
+
+    def _finalize(self, changes):
+        """Post-commit side effects; must not fail the edit."""
+        model = self.model
+
+        # 1. Trace invalidation for removed and modified members
+        for impl in changes.removed:
+            if isinstance(impl, ReferenceImpl):
+                model.clear_attr_referrers(impl)
+            else:
+                model.clear_obj(impl)
+        for impl in changes.modified:
+            if isinstance(impl, ReferenceImpl):
+                model.clear_attr_referrers(impl)
+            else:
+                model.clear_obj(impl)
+
+        # 2. Finalize deletions
+        for impl in changes.removed:
+            impl.on_delete()
+
+        # 3. Batched notify: exactly one namespace invalidation per
+        #    dirty container. The itemspace-deletion half of
+        #    DynamicBase.on_notify is handled by ItemSpaceManager below.
+        for parent, attr in changes.dirty_containers:
+            container = getattr(parent, attr)
+            if parent.is_model():
+                for space in parent.yield_spaces():
+                    NamespaceServer.on_notify(space, container)
+            else:
+                NamespaceServer.on_notify(parent, container)
+
+        # 4. ValueRegistry / IOSpec bookkeeping
+        for op in changes.registry_ops:
+            if op[0] == "register":
+                model.valreg.register(op[1])
+            elif op[0] == "unregister":
+                model.valreg.unregister(op[1])
+            elif op[0] == "rebind":
+                model.valreg.rebind(op[1], op[2])
+            else:
+                raise RuntimeError("must not happen")
+
+        # 5. Itemspace invalidation (verbatim pre-pipeline policy)
+        model.itemspacemgr.invalidate(changes)
+
+
+# ----------------------------------------------------------------------
+# Space-level reference edits
+
+
+def _create_ref(txn, space, name, value, is_derived, refmode):
+    ref = ReferenceImpl(space, name, value, container=space.own_refs,
+                        is_derived=is_derived, refmode=refmode)
+    txn.set_item(space.own_refs, name, ref)
+    txn.add_created(ref)
+    txn.mark_dirty(space, "own_refs")
+    return ref
+
+
+def _replace_ref(txn, space, name, value, is_derived, refmode):
+    old = space.own_refs[name]
+    txn.del_item(space.own_refs, name)
+    txn.add_removed(old)
+    new = _create_ref(txn, space, name, value, is_derived, refmode)
+    return old, new
+
+
+class NewRef(Edit):
+    """Create a reference in a space and derive it into sub spaces."""
+
+    def __init__(self, space, name, value, refmode, register=False):
+        self.space = space
+        self.name = name
+        self.value = value
+        self.refmode = refmode
+        self.register = register
+
+    def validate(self, model, txn):
+        spmgr = model.spmgr
+        other = spmgr._find_name_in_subs(self.space, self.name)
+        if other is not None:
+            if not isinstance(other, ReferenceImpl):
+                raise ValueError("Cannot create reference '%s'" % self.name)
+            elif other not in model.global_refs.values():
+                raise ValueError("Cannot create reference '%s'" % self.name)
+
+        spmgr._check_subs_relrefs(
+            self.space, self.name, self.value, self.refmode)
+
+    def apply(self, model, txn):
+        ref = _create_ref(txn, self.space, self.name, self.value,
+                          is_derived=False, refmode=self.refmode)
+        if self.register:
+            txn.changes.registry_ops.append(("register", ref))
+        self.result = ref
+
+    def derive(self, model, txn):
+        spmgr = model.spmgr
+        space, name, refmode = self.space, self.name, self.refmode
+        value = self.value
+
+        for subspace in spmgr._get_subs(space):
+            is_relative = False
+            if name in subspace.own_refs:
+                break
+            if isinstance(value, Interface) and value._is_valid():
+                if refmode == "auto" or refmode == "relative":
+                    is_relative, value = spmgr.get_relative_interface(
+                        subspace, space.own_refs[name])
+            ref = _create_ref(txn, subspace, name, value,
+                              is_derived=True, refmode=refmode)
+            ref.is_relative = is_relative
+
+
+class ChangeRef(Edit):
+    """Assign a new value to an existing reference in a space."""
+
+    def __init__(self, space, name, value, refmode, rebind=False):
+        self.space = space
+        self.name = name
+        self.value = value
+        self.refmode = refmode
+        self.rebind = rebind
+
+    def validate(self, model, txn):
+        model.spmgr._check_subs_relrefs(
+            self.space, self.name, self.value, self.refmode)
+
+    def apply(self, model, txn):
+        old, new = _replace_ref(txn, self.space, self.name, self.value,
+                                is_derived=False, refmode=self.refmode)
+        if self.rebind:
+            txn.changes.registry_ops.append(("rebind", old, new))
+
+    def derive(self, model, txn):
+        spmgr = model.spmgr
+        space, name, refmode = self.space, self.name, self.refmode
+        value = self.value
+
+        for subspace in spmgr._get_subs(space):
+            is_relative = False
+            subref = subspace.own_refs[name]
+            if subref.is_defined():
+                break
+            elif subref.defined_bases[0] is not space.own_refs[name]:
+                break
+            if isinstance(value, Interface) and value._is_valid():
+                if refmode == "auto" or refmode == "relative":
+                    is_relative, value = spmgr.get_relative_interface(
+                        subspace, space.own_refs[name])
+            old, _ = _replace_ref(txn, subspace, name, value,
+                                  is_derived=True, refmode=refmode)
+            # Preserved pre-pipeline behavior: SpaceManager.change_ref
+            # assigned the resolved is_relative to the object returned by
+            # on_change_ref, which was the replaced (old) ref; the new
+            # derived ref keeps the flag its constructor derives from
+            # refmode.
+            txn.set_attr(old, "is_relative", is_relative)
+
+
+class DelRef(Edit):
+    """Delete a reference from a space and re-derive its sub spaces."""
+
+    def __init__(self, space, name, unregister=False):
+        self.space = space
+        self.name = name
+        self.unregister = unregister
+
+    def apply(self, model, txn):
+        ref = self.space.own_refs[self.name]
+        txn.del_item(self.space.own_refs, self.name)
+        txn.add_removed(ref)
+        txn.mark_dirty(self.space, "own_refs")
+        if self.unregister:
+            txn.changes.registry_ops.append(("unregister", ref))
+
+    def derive(self, model, txn):
+        # Mirrors SharedSpaceOperations.update_subs(space, skip_self=False):
+        # reconcile 'cells' across all affected spaces before 'own_refs'
+        # (the two-phase inheritance order, CoreRefactorDesign §2.1).
+        spmgr = model.spmgr
+        for attr in ("cells", "own_refs"):
+            for s in spmgr._get_subs(self.space, skip_self=False):
+                bases = spmgr._get_space_bases(s)
+                s.on_inherit(spmgr, bases, attr, txn=txn)
+
+
+# ----------------------------------------------------------------------
+# Model-global reference edits
+
+
+class NewGlobalRef(Edit):
+    """Create a global reference on the model."""
+
+    def __init__(self, model, name, value, register=False):
+        self.name = name
+        self.value = value
+        self.register = register
+
+    def apply(self, model, txn):
+        ref = ReferenceImpl(model, name=self.name, value=self.value,
+                            container=model._global_refs)
+        txn.set_item(model._global_refs, self.name, ref)
+        txn.add_created(ref)
+        txn.mark_dirty(model, "global_refs")
+        if self.register:
+            txn.changes.registry_ops.append(("register", ref))
+        self.result = ref
+
+
+class DelGlobalRef(Edit):
+    """Delete a global reference from the model."""
+
+    def __init__(self, model, name, unregister=False):
+        self.name = name
+        self.unregister = unregister
+
+    def apply(self, model, txn):
+        ref = model.global_refs[self.name]
+        txn.del_item(model._global_refs, self.name)
+        txn.add_removed(ref)
+        txn.mark_dirty(model, "global_refs")
+        if self.unregister:
+            txn.changes.registry_ops.append(("unregister", ref))
+
+
+class ChangeGlobalRef(Edit):
+    """Assign a new value to an existing global reference."""
+
+    def __init__(self, model, name, value, rebind=False):
+        self.name = name
+        self.value = value
+        self.rebind = rebind
+
+    def apply(self, model, txn):
+        old = model.global_refs[self.name]
+        txn.del_item(model._global_refs, self.name)
+        txn.add_removed(old)
+        new = ReferenceImpl(model, name=self.name, value=self.value,
+                            container=model._global_refs)
+        txn.set_item(model._global_refs, self.name, new)
+        txn.add_created(new)
+        txn.mark_dirty(model, "global_refs")
+        if self.rebind:
+            txn.changes.registry_ops.append(("rebind", old, new))
+        self.result = new

--- a/modelx/core/edit/transaction.py
+++ b/modelx/core/edit/transaction.py
@@ -47,3 +47,140 @@ class InstructionList(list):
         if clear:
             self.clear()
         return result
+
+
+class ChangeSet:
+    """What one committed edit did to the model (CoreRefactorDesign §5.4).
+
+    Collected by :class:`Transaction` while an Edit runs and consumed by
+    ``ModelEditor._finalize`` after commit. ``dirty_containers`` and
+    ``dirty_spaces`` are dicts used as insertion-ordered sets so that
+    post-commit notification order is deterministic.
+    """
+
+    __slots__ = (
+        "created",
+        "removed",
+        "modified",
+        "dirty_containers",
+        "dirty_spaces",
+        "registry_ops"
+    )
+
+    def __init__(self):
+        self.created = []           # new impls, including derived ones
+        self.removed = []           # impls taken out of containers
+        self.modified = []          # impls rebound/changed in place
+        self.dirty_containers = {}  # (parent_impl, attr) -> None
+        self.dirty_spaces = {}      # idstr -> None
+        self.registry_ops = []      # ValueRegistry ops run in finalize:
+                                    # ("register", ref) / ("unregister", ref)
+                                    # / ("rebind", old_ref, new_ref)
+
+
+def _insert_at(container, key, value, index):
+    """Insert ``key: value`` into ``container`` at position ``index``."""
+    tail = [k for k in list(container) if k != key][index:]
+    container[key] = value
+    for k in tail:
+        container[k] = container.pop(k)
+
+
+class Transaction:
+    """Undo journal over container writes (CoreRefactorDesign §5.4).
+
+    Edits route every structural write through this object so that
+    ``rollback`` can restore the model bit-identically — including dict
+    ordering, which is observable through namespaces and serialization.
+    The shadow-graph half arrives with the graph-mutating edits
+    (Phase 6); the reference edits of Phase 4 do not touch the
+    inheritance graph.
+    """
+
+    def __init__(self, model):
+        self.model = model
+        self.changes = ChangeSet()
+        self._journal = []      # undo records, replayed in reverse
+
+    # ----------------------------------------------------------------------
+    # Journaled writes
+
+    def set_item(self, container, key, value):
+        if key in container:
+            self._journal.append(("replace", container, key, container[key]))
+        else:
+            self._journal.append(("add", container, key))
+        container[key] = value
+
+    def del_item(self, container, key):
+        index = list(container).index(key)
+        self._journal.append(("del", container, key, container[key], index))
+        del container[key]
+
+    def move_to_end(self, container, key):
+        index = list(container).index(key)
+        self._journal.append(("move", container, key, index))
+        container[key] = container.pop(key)
+
+    def set_attr(self, obj, attr, value):
+        self._journal.append(("attr", obj, attr, getattr(obj, attr)))
+        setattr(obj, attr, value)
+
+    def add_undo(self, func, *args):
+        """Journal an undo callback for a side effect the caller performed
+        outside the journaled writes (e.g. observer registration done by
+        a constructor)."""
+        self._journal.append(("undo", func, args))
+
+    # ----------------------------------------------------------------------
+    # ChangeSet bookkeeping
+
+    def add_created(self, impl):
+        self.changes.created.append(impl)
+
+    def add_removed(self, impl):
+        self.changes.removed.append(impl)
+
+    def add_modified(self, impl):
+        self.changes.modified.append(impl)
+
+    def mark_dirty(self, parent, attr):
+        self.changes.dirty_containers[(parent, attr)] = None
+        if not parent.is_model():
+            self.changes.dirty_spaces[parent.idstr] = None
+
+    # ----------------------------------------------------------------------
+    # Outcome
+
+    def rollback(self):
+        """Reverse-replay the journal; the model is bit-identical to the
+        state before the edit. No notify/trace/registry actions have run
+        (they are all post-commit)."""
+        while self._journal:
+            record = self._journal.pop()
+            kind = record[0]
+            if kind == "add":
+                _, container, key = record
+                del container[key]
+            elif kind == "replace":
+                _, container, key, old = record
+                container[key] = old
+            elif kind == "del":
+                _, container, key, old, index = record
+                _insert_at(container, key, old, index)
+            elif kind == "move":
+                _, container, key, index = record
+                value = container.pop(key)
+                _insert_at(container, key, value, index)
+            elif kind == "attr":
+                _, obj, attr, old = record
+                setattr(obj, attr, old)
+            elif kind == "undo":
+                _, func, args = record
+                func(*args)
+            else:
+                raise RuntimeError("must not happen")
+        self.changes = ChangeSet()
+
+    def commit(self):
+        self._journal.clear()

--- a/modelx/core/inheritance/manager.py
+++ b/modelx/core/inheritance/manager.py
@@ -22,7 +22,6 @@ from modelx.core.base import (
     Derivable,
     null_impl
 )
-from modelx.core.reference import ReferenceImpl
 from modelx.core.cells import CellsImpl, UserCellsImpl
 from modelx.core.parent import EditableParentImpl
 from modelx.core.space import UserSpaceImpl
@@ -31,6 +30,7 @@ from modelx.core.formula import NULL_FORMULA
 from modelx.core.util import is_valid_name
 from modelx.core.inheritance.graph import SpaceGraph, split_node
 from modelx.core.edit.transaction import Instruction, InstructionList
+from modelx.core.edit.pipeline import NewRef, ChangeRef, DelRef
 
 
 class SharedSpaceOperations:
@@ -172,9 +172,9 @@ class SpaceManager(SharedSpaceOperations):
         space.on_del_cells(name)
         self.update_subs(space, skip_self=False)
 
-    def del_ref(self, space, name):
-        space.on_del_ref(name)
-        self.update_subs(space, skip_self=False)
+    def del_ref(self, space, name, unregister=False):
+        self.model.editor.execute(
+            DelRef(space, name, unregister=unregister))
 
     def new_cells(self, space, name=None, formula=None, data=None,
                   is_derived=False, is_cached=True, edit_source=True):
@@ -300,61 +300,14 @@ class SpaceManager(SharedSpaceOperations):
                             % (basevalue, subspace.idstr)
                         )
 
-    def new_ref(self, space, name, value, refmode):
+    def new_ref(self, space, name, value, refmode, register=False):
+        return self.model.editor.execute(
+            NewRef(space, name, value, refmode, register=register))
 
-        other = self._find_name_in_subs(space, name)
-        if other is not None:
-            if not isinstance(other, ReferenceImpl):
-                raise ValueError("Cannot create reference '%s'" % name)
-            elif other not in self.model.global_refs.values():
-                raise ValueError("Cannot create reference '%s'" % name)
-
-        self._check_subs_relrefs(space, name, value, refmode)
-        result = space.on_create_ref(name, value, is_derived=False,
-                            refmode=refmode)
-
-        for subspace in self._get_subs(space):
-            is_relative = False
-            if name in subspace.own_refs:
-                break
-            if isinstance(value, Interface) and value._is_valid():
-                if refmode == "auto" or refmode == "relative":
-                    is_relative, value = self.get_relative_interface(
-                        subspace, space.own_refs[name])
-            ref = subspace.on_create_ref(name, value, is_derived=True,
-                                   refmode=refmode)
-            ref.is_relative = is_relative
-
-        return result
-
-    def change_ref(self, space, name, value, refmode):
+    def change_ref(self, space, name, value, refmode, rebind=False):
         """Assigns a new value to an existing name."""
-
-        self._check_subs_relrefs(space, name, value, refmode)
-        # self._set_defined(space.idstr)
-        # space.set_defined()
-
-        is_relative = False if refmode == "absolute" else True
-
-        space.on_change_ref(name, value, is_derived=False, refmode=refmode,
-                            is_relative=is_relative)
-
-        for subspace in self._get_subs(space):
-            is_relative = False
-            subref = subspace.own_refs[name]
-            if subref.is_defined():
-                break
-            elif subref.defined_bases[0] is not space.own_refs[name]:
-                break
-            if isinstance(value, Interface) and value._is_valid():
-                if (refmode == "auto"
-                        or refmode == "relative"):
-                    is_relative, value = self.get_relative_interface(
-                        subspace, space.own_refs[name])
-            ref = subspace.on_change_ref(name, value,
-                                         is_derived=True, refmode=refmode,
-                                         is_relative=is_relative)
-            ref.is_relative = is_relative
+        self.model.editor.execute(
+            ChangeRef(space, name, value, refmode, rebind=rebind))
 
     def _check_sanity(self):
 

--- a/modelx/core/itemspaces.py
+++ b/modelx/core/itemspaces.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
+
+# This library is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation version 3.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ItemSpaceManager:
+    """Per-model itemspace invalidation policy (CoreRefactorDesign §5.8).
+
+    Phase 4 carries the pre-pipeline nuke-all policy verbatim from
+    ``DynamicBase.on_notify``: a namespace change on a space deletes all
+    of the space's own itemspaces, plus all itemspaces of the parent of
+    each of its dynamic subs' root spaces. A model-global change applies
+    this to every space, matching the previous per-space ``on_notify``
+    fan-out. Phase 7 replaces this with closure-based selective
+    invalidation.
+
+    Stateless: constructed per access by ``ModelImpl.itemspacemgr`` so
+    that no new slot enters pickled model state.
+    """
+
+    def __init__(self, model):
+        self.model = model
+
+    def invalidate(self, changes):
+        spaces = {}     # dict as insertion-ordered set
+        for parent, attr in changes.dirty_containers:
+            if parent.is_model():
+                for space in parent.yield_spaces():
+                    spaces[space] = None
+            else:
+                spaces[parent] = None
+
+        for space in spaces:
+            self._invalidate_space(space)
+
+    def _invalidate_space(self, space):
+        space.del_all_itemspaces()
+        # Use dict instead of list to avoid duplicates
+        for r in {s.rootspace: True for s in space._dynamic_subs}:
+            r.parent.del_all_itemspaces()

--- a/modelx/core/model.py
+++ b/modelx/core/model.py
@@ -57,6 +57,13 @@ from modelx.core.inheritance.manager import (
     SpaceUpdater,
 )
 from modelx.core.edit.transaction import Instruction, InstructionList
+from modelx.core.edit.pipeline import (
+    ModelEditor,
+    NewGlobalRef,
+    ChangeGlobalRef,
+    DelGlobalRef,
+)
+from modelx.core.itemspaces import ItemSpaceManager
 from modelx.core.refs import ValueRegistry, ReferenceManager
 
 
@@ -496,8 +503,8 @@ class Model(IOSpecOperation, EditableParent):
         self._impl.clear_attr_referrers(self._impl.property_refs["path"])
         self._impl.path = pathlib.Path(path)
         self._impl.property_refs['path'] = ReferenceImpl(
-            self._impl, "path", self._impl.path, container=self._impl._property_refs,
-            set_item=False)
+            self._impl, "path", self._impl.path,
+            container=self._impl._property_refs)
 
     def write(self, model_path, backup=True, log_input=False):
         """Write model to files.
@@ -1207,12 +1214,10 @@ class ModelImpl(*_model_impl_base):
         self.path = None
         self._global_refs = {}
         self._global_refs['__builtins__'] = ReferenceImpl(
-            self, '__builtins__', builtins, container=self._global_refs,
-            set_item=False)
+            self, '__builtins__', builtins, container=self._global_refs)
         self._property_refs = {}
         self._property_refs["path"] = ReferenceImpl(
-            self, "path", self.path, container=self._property_refs,
-            set_item=False)
+            self, "path", self.path, container=self._property_refs)
         self._macros = {}
         self._macro_namespace = None
         self.named_spaces = {}
@@ -1280,26 +1285,29 @@ class ModelImpl(*_model_impl_base):
     def updater(self):
         return SpaceUpdater(self.spmgr)
 
-    def del_ref(self, name):
-        ref = self.global_refs[name]
-        self.model.clear_attr_referrers(ref)
-        ref.on_delete()
-        del self.global_refs[name]
-        for space in self.yield_spaces():
-            space.on_notify(self.global_refs)
+    @property
+    def editor(self):
+        """The mutation pipeline entry point (CoreRefactorDesign §5.4).
 
-    def change_ref(self, name, value):
-        self.del_ref(name)
-        self.new_ref(name, value)
+        Stateless, so it is constructed per access instead of adding a
+        slot to pickled model state.
+        """
+        return ModelEditor(self)
 
-    def new_ref(self, name, value):
-        ref = ReferenceImpl(
-            self, name, value, container=self._global_refs,
-            set_item=False)
-        self._global_refs[name] = ref
-        for space in self.yield_spaces():
-            space.on_notify(self.global_refs)
-        return ref
+    @property
+    def itemspacemgr(self):
+        """Per-model itemspace invalidation policy (§5.8); stateless."""
+        return ItemSpaceManager(self)
+
+    def del_ref(self, name, unregister=False):
+        self.editor.execute(DelGlobalRef(self, name, unregister=unregister))
+
+    def change_ref(self, name, value, rebind=False):
+        self.editor.execute(ChangeGlobalRef(self, name, value, rebind=rebind))
+
+    def new_ref(self, name, value, register=False):
+        return self.editor.execute(
+            NewGlobalRef(self, name, value, register=register))
 
     def get_attr(self, name):
         if name in self.spaces:
@@ -1319,12 +1327,9 @@ class ModelImpl(*_model_impl_base):
         elif name in self._macros:
             raise KeyError("Macro named '%s' already exists" % name)
         elif name in self.global_refs:
-            prev_ref = self.global_refs[name]
-            self.change_ref(name, value)
-            self.valreg.rebind(prev_ref, self.global_refs[name])
+            self.change_ref(name, value, rebind=True)
         else:
-            ref = self.new_ref(name, value)
-            self.valreg.register(ref)
+            self.new_ref(name, value, register=True)
 
     def del_attr(self, name):
 
@@ -1333,9 +1338,7 @@ class ModelImpl(*_model_impl_base):
         elif name in self._macros:
             self.del_macro(name)
         elif name in self.global_refs:
-            ref = self.global_refs[name]
-            self.del_ref(name)
-            self.valreg.unregister(ref)
+            self.del_ref(name, unregister=True)
         else:
             raise KeyError("Name '%s' not defined" % name)
 

--- a/modelx/core/reference.py
+++ b/modelx/core/reference.py
@@ -33,7 +33,9 @@ class ReferenceImpl(Derivable, Impl):
     ) + get_mixin_slots(Derivable, Impl)
 
     def __init__(self, parent, name, value, container, is_derived=False,
-                 refmode=None, set_item=True):
+                 refmode=None):
+        # Side-effect-free: the caller registers self into ``container``
+        # (D-11; registration happens in the pipeline's apply stage).
         Impl.__init__(
             self,
             system=parent.system,
@@ -45,9 +47,6 @@ class ReferenceImpl(Derivable, Impl):
         Derivable.__init__(self, is_derived)
 
         self.container = container
-        if set_item:
-            container.set_item(name, self)
-
         self.refmode = refmode
         if refmode == "absolute":
             self.is_relative = False
@@ -77,34 +76,59 @@ class ReferenceImpl(Derivable, Impl):
         return (isinstance(self.interface, Interface)
                 and self.interface._is_valid())
 
-    def on_inherit(self, updater, bases):
+    def on_inherit(self, updater, bases, txn=None):
+        """Re-derive self from ``bases[0]``.
 
-        self.model.clear_attr_referrers(self)
+        Without ``txn``, mutates self immediately and clears the trace
+        graph (pre-pipeline behavior, still used by SpaceUpdater).
+        With ``txn``, the resolution is computed first (so an
+        out-of-scope error aborts the edit before any state change),
+        writes are journaled, and trace clearing is deferred to the
+        pipeline finalize stage — and skipped entirely when the binding
+        is unchanged.
+        """
+        if txn is None:
+            self.model.clear_attr_referrers(self)
+
         if bases[0].has_interface():
 
             if self.refmode == "absolute":
-                self.interface = bases[0].interface
-                self.is_relative = False
+                is_relative = False
+                interface = bases[0].interface
             else:
                 is_relative, interface = updater.get_relative_interface(
                     self.parent,
                     bases[0])
                 if self.refmode == "auto":
-                    self.is_relative = is_relative
-                    self.interface = interface
+                    pass
                 elif self.refmode == "relative":
-                    if is_relative:
-                        self.is_relative = is_relative
-                        self.interface = interface
-                    else:
+                    if not is_relative:
                         raise ValueError(
                             "Relative reference %s out of scope" %
                             self.get_fullname()
                         )
                 else:
                     raise ValueError("must not happen")
+
+            if txn is None:
+                self.is_relative = is_relative
+                self.interface = interface
+            elif (interface is not self.interface
+                    or is_relative != self.is_relative):
+                txn.set_attr(self, "is_relative", is_relative)
+                txn.set_attr(self, "interface", interface)
+                txn.add_modified(self)
+                # Ref values are baked into ns_dict, so a rebind must
+                # invalidate the namespaces seeing this ref.
+                txn.mark_dirty(self.parent, "own_refs")
         else:
-            self.interface = bases[0].interface
+            interface = bases[0].interface
+            if txn is None:
+                self.interface = interface
+            elif interface is not self.interface:
+                txn.set_attr(self, "interface", interface)
+                txn.add_modified(self)
+                txn.mark_dirty(self.parent, "own_refs")
 
 
 class NameSpaceReferenceImpl(ReferenceImpl):

--- a/modelx/core/refs.py
+++ b/modelx/core/refs.py
@@ -33,12 +33,14 @@ class ValueRegistry:
     """Tracks non-Interface values assigned to References (Phase 3).
 
     Successor to ``ReferenceManager``. The ``register``/``unregister``/
-    ``rebind`` hooks below are pure bookkeeping: the callers
-    (``ModelImpl.set_attr``/``del_attr``, ``UserSpaceImpl.set_attr``/
-    ``del_ref``) invoke the spmgr/ModelImpl mutators directly and then
-    the hooks. The one remaining mutation path is ``update_value``,
-    which rebinds refs through ``parent.on_update_ref``; it is slated
-    to become an Edit in Phase 4.
+    ``rebind`` hooks below are pure bookkeeping, invoked by the edit
+    pipeline's finalize stage (Phase 4): the ref Edits carry
+    ``register``/``rebind``/``unregister`` directives recorded in the
+    ChangeSet. The one remaining mutation path here is
+    ``update_value``, which rebinds refs through
+    ``parent.on_update_ref`` (each rebinding runs a ChangeRef edit);
+    reimplementing it as a single Edit is deferred until recalculation
+    targeting moves into the pipeline (design §5.8).
 
     Only refs assigned through those attribute-access paths are
     registered; derived refs and refs created by

--- a/modelx/core/space.py
+++ b/modelx/core/space.py
@@ -1978,9 +1978,9 @@ class BaseSpaceImpl(*_base_space_impl_base):
 
         NamespaceServer.__init__(self)
         self.sys_refs.update(
-            _self=NameSpaceReferenceImpl(self, '_self', self._namespace, self.sys_refs, set_item=False),
-            _space=NameSpaceReferenceImpl(self, '_space', self._namespace, self.sys_refs, set_item=False),
-            _model=NameSpaceReferenceImpl(self, '_model', self.model.namespace, self.sys_refs, set_item=False)
+            _self=NameSpaceReferenceImpl(self, '_self', self._namespace, self.sys_refs),
+            _space=NameSpaceReferenceImpl(self, '_space', self._namespace, self.sys_refs),
+            _model=NameSpaceReferenceImpl(self, '_model', self.model.namespace, self.sys_refs)
         )
 
         ItemSpaceParent.__init__(self, formula)
@@ -1997,7 +1997,7 @@ class BaseSpaceImpl(*_base_space_impl_base):
         if refs is not None:
             for key, value in refs.items():
                 self.own_refs[key] = ReferenceImpl(self, key, value, container=self.own_refs,
-                              refmode="auto", set_item=False)
+                              refmode="auto")
 
 
     def on_update_ns(self):
@@ -2143,12 +2143,6 @@ class DynamicBase(BaseSpaceImpl):
         for r in {s.rootspace: True for s in self._dynamic_subs}:
             r.parent.del_all_itemspaces()
         BaseSpaceImpl.on_notify(self, subject)
-
-    def change_dynsub_refs(self, name):
-
-        for dynsub in self._dynamic_subs:
-            baseref = self.own_refs[name]
-            dynsub._dynbase_refs.set_item(name, baseref)
 
     def clear_subs_rootitems(self):
         for dynsub in self._dynamic_subs.copy():
@@ -2323,12 +2317,11 @@ class UserSpaceImpl(*_user_space_impl_base):
         if self.get_attr(name) is not None:
             if name in self.refs:
                 if name in self.own_refs:
-                    prev_ref = self.own_refs[name]
-                    self.model.spmgr.change_ref(self, name, value, refmode)
-                    self.model.valreg.rebind(prev_ref, self.own_refs[name])
+                    self.model.spmgr.change_ref(self, name, value, refmode,
+                                                rebind=True)
                 elif self.refs[name].parent is self.model:
-                    ref = self.model.spmgr.new_ref(self, name, value, refmode)
-                    self.model.valreg.register(ref)
+                    self.model.spmgr.new_ref(self, name, value, refmode,
+                                             register=True)
                 else:
                     raise RuntimeError("must not happen")
 
@@ -2340,8 +2333,8 @@ class UserSpaceImpl(*_user_space_impl_base):
             else:
                 raise ValueError
         else:
-            ref = self.model.spmgr.new_ref(self, name, value, refmode)
-            self.model.valreg.register(ref)
+            self.model.spmgr.new_ref(self, name, value, refmode,
+                                     register=True)
 
     def del_attr(self, name):
         """Implementation of attribute deletion
@@ -2369,9 +2362,7 @@ class UserSpaceImpl(*_user_space_impl_base):
     def del_ref(self, name):
 
         if name in self.own_refs:
-            ref = self.own_refs[name]
-            self.model.spmgr.del_ref(self, name)
-            self.model.valreg.unregister(ref)
+            self.model.spmgr.del_ref(self, name, unregister=True)
         elif name in self.is_derived():
             raise KeyError("Derived ref '%s' cannot be deleted" % name)
         elif name in self.arguments:
@@ -2421,8 +2412,15 @@ class UserSpaceImpl(*_user_space_impl_base):
         for name in cells_to_update:
             self.cells[name].reload(module=modsrc)
 
-    def on_inherit(self, updater, bases, attr):
+    def on_inherit(self, updater, bases, attr, txn=None):
+        """Reconcile ``attr`` ('cells' or 'own_refs') against ``bases``.
 
+        Without ``txn``: pre-pipeline behavior (immediate writes, used
+        by SpaceUpdater). With ``txn``: container writes are journaled,
+        notification/trace/deletion side effects are deferred to the
+        pipeline finalize stage. Phase 5 absorbs this reconciliation
+        into InheritanceSync.
+        """
         attrs = {
             "cells": self.on_del_cells,
             "own_refs": self.on_del_ref
@@ -2440,34 +2438,62 @@ class UserSpaceImpl(*_user_space_impl_base):
             if name not in selfdict:
 
                 if attr == "cells":
-                    selfdict[name] = UserCellsImpl(
-                        space=self, name=name, formula=None,
-                        is_derived=True)
+                    if txn is None:
+                        selfdict[name] = UserCellsImpl(
+                            space=self, name=name, formula=None,
+                            is_derived=True)
+                    else:
+                        cells = UserCellsImpl(
+                            space=self, name=name, formula=None,
+                            is_derived=True, add_to_space=False)
+                        # The constructor registered the cells as an
+                        # observer of self; undo that on rollback.
+                        txn.add_undo(self.remove_observer, cells)
+                        txn.set_item(selfdict, name, cells)
+                        txn.add_created(cells)
+                        txn.mark_dirty(self, attr)
 
                 elif attr == "own_refs":
-                    selfdict[name] = ReferenceImpl(
+                    ref = ReferenceImpl(
                         self, name, None,
                         container=self.own_refs,
                         is_derived=True,
-                        refmode=bs[0].refmode,
-                        set_item=False
+                        refmode=bs[0].refmode
                     )
+                    if txn is None:
+                        selfdict[name] = ref
+                    else:
+                        txn.set_item(selfdict, name, ref)
+                        txn.add_created(ref)
+                        txn.mark_dirty(self, attr)
                 else:
                     raise RuntimeError("must not happen")
 
             else:
                 # Remove & add back for reorder
-                selfdict[name] = selfdict.pop(name)
+                if txn is None:
+                    selfdict[name] = selfdict.pop(name)
+                else:
+                    txn.move_to_end(selfdict, name)
                 selfkeys.remove(name)
 
             if selfdict[name].is_derived():
-                selfdict[name].on_inherit(updater, bs)
+                selfdict[name].on_inherit(updater, bs, txn=txn)
 
         for name in selfkeys:
             if selfdict[name].is_derived():
-                attrs[attr](name)
+                if txn is None:
+                    attrs[attr](name)
+                else:
+                    member = selfdict[name]
+                    txn.del_item(selfdict, name)
+                    txn.add_removed(member)
+                    txn.mark_dirty(self, attr)
             else:   # defined
-                selfdict[name] = selfdict.pop(name)
+                if txn is None:
+                    selfdict[name] = selfdict.pop(name)
+                else:
+                    txn.move_to_end(selfdict, name)
 
     def on_del_cells(self, name):
         cells = self.cells[name]
@@ -2508,25 +2534,6 @@ class UserSpaceImpl(*_user_space_impl_base):
             keys = None
 
         sort_dict(self.cells, keys)
-
-    def on_change_ref(self, name, value, is_derived, refmode,
-                      is_relative):
-        ref = self.own_refs[name]
-        self.on_del_ref(name)
-        self.on_create_ref(name, value, is_derived, refmode)
-        self.model.clear_attr_referrers(ref)
-        self.change_dynsub_refs(name)
-        return ref
-
-    def on_create_ref(self, name, value, is_derived, refmode):
-        ref = ReferenceImpl(self, name, value,
-                            container=self.own_refs,
-                            is_derived=is_derived,
-                            refmode=refmode,
-                            set_item=False)
-        self.own_refs[name] = ref
-        self.on_notify(self.own_refs)
-        return ref
 
     def on_del_ref(self, name):
         self.model.clear_attr_referrers(self.own_refs[name])
@@ -2843,7 +2850,7 @@ class ItemSpaceImpl(DynamicSpaceImpl):
     def _init_refs(self, arguments=None):
         args = {}
         for k, v in arguments.items():
-            args[k] = ReferenceImpl(self, k, v, container=args, set_item=False)
+            args[k] = ReferenceImpl(self, k, v, container=args)
         self._arguments = args
         DynamicSpaceImpl._init_refs(self)
 

--- a/modelx/tests/core/edit/test_transaction.py
+++ b/modelx/tests/core/edit/test_transaction.py
@@ -1,0 +1,100 @@
+"""Unit tests for the Phase 4 edit-pipeline transaction journal.
+
+The Transaction must restore containers bit-identically on rollback,
+including dict ordering, which is observable through namespaces and
+serialized models (CoreRefactorDesign.md §5.4).
+"""
+
+import pytest
+
+from modelx.core.edit.transaction import Transaction, ChangeSet
+
+
+class _FakeModel:
+    def is_model(self):
+        return True
+
+
+@pytest.fixture
+def txn():
+    return Transaction(_FakeModel())
+
+
+def test_rollback_restores_order_after_del(txn):
+    d = {"a": 1, "b": 2, "c": 3, "d": 4}
+    txn.del_item(d, "b")
+    assert list(d) == ["a", "c", "d"]
+    txn.rollback()
+    assert d == {"a": 1, "b": 2, "c": 3, "d": 4}
+    assert list(d) == ["a", "b", "c", "d"]
+
+
+def test_rollback_restores_order_after_move(txn):
+    d = {"a": 1, "b": 2, "c": 3}
+    txn.move_to_end(d, "a")
+    assert list(d) == ["b", "c", "a"]
+    txn.rollback()
+    assert list(d) == ["a", "b", "c"]
+
+
+def test_rollback_removes_added_and_restores_replaced(txn):
+    d = {"a": 1}
+    txn.set_item(d, "b", 2)      # add
+    txn.set_item(d, "a", 10)     # replace
+    txn.rollback()
+    assert d == {"a": 1}
+    assert list(d) == ["a"]
+
+
+def test_rollback_interleaved_ops(txn):
+    d = {"a": 1, "b": 2, "c": 3}
+    txn.del_item(d, "a")
+    txn.set_item(d, "x", 9)
+    txn.move_to_end(d, "b")
+    txn.del_item(d, "c")
+    txn.set_item(d, "b", 20)
+    assert list(d) == ["x", "b"]
+    txn.rollback()
+    assert d == {"a": 1, "b": 2, "c": 3}
+    assert list(d) == ["a", "b", "c"]
+
+
+def test_rollback_restores_attrs_and_runs_undo_callbacks(txn):
+    class Obj:
+        pass
+
+    obj = Obj()
+    obj.value = 1
+    calls = []
+
+    txn.set_attr(obj, "value", 2)
+    txn.add_undo(calls.append, "undone")
+    txn.rollback()
+
+    assert obj.value == 1
+    assert calls == ["undone"]
+
+
+def test_rollback_resets_changeset(txn):
+    d = {}
+    txn.set_item(d, "a", 1)
+    txn.add_created("impl")
+    txn.mark_dirty(_FakeModel(), "global_refs")
+    txn.rollback()
+    assert txn.changes.created == []
+    assert txn.changes.dirty_containers == {}
+
+
+def test_commit_clears_journal(txn):
+    d = {"a": 1}
+    txn.set_item(d, "b", 2)
+    txn.commit()
+    txn.rollback()      # nothing to undo after commit
+    assert d == {"a": 1, "b": 2}
+
+
+def test_changeset_defaults():
+    ch = ChangeSet()
+    assert ch.created == [] and ch.removed == [] and ch.modified == []
+    assert ch.dirty_containers == {} and ch.dirty_spaces == {}
+    assert ch.registry_ops == []

--- a/modelx/tests/core/reference/test_recalc_base_ref_change.py
+++ b/modelx/tests/core/reference/test_recalc_base_ref_change.py
@@ -111,21 +111,16 @@ def test_recalc_on_override_delete_direct(inheritance_chain):
     assert Mid.foo(3) == 6
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="UserSpaceImpl.on_inherit rewrites sub containers without"
-           " on_notify: after deleting a mid-chain override, deeper subs"
-           " re-derive the ref value but their namespaces stay stale"
-           " (CoreRefactorDesign.md problem 3; fixed by the pipeline's"
-           " batched notify)",
-)
 def test_recalc_on_override_delete_deeper_sub(inheritance_chain):
     """Deleting an overriding ref must also re-expose the base value in
     subs further down the chain.
 
-    Currently Leaf's own_refs['mult'] is correctly re-derived to 2, but
-    Leaf.foo keeps evaluating with the stale namespace binding (3) —
-    even after clearing its values.
+    Was xfail(strict=True) before Phase 4: the pre-pipeline
+    ``UserSpaceImpl.on_inherit`` rewrote sub containers without
+    ``on_notify``, so Leaf's ``own_refs['mult']`` was re-derived to 2
+    but Leaf.foo kept evaluating with the stale namespace binding (3).
+    The pipeline's batched notify (CoreRefactorDesign.md §5.4) marks
+    rebound refs' containers dirty and invalidates their namespaces.
     """
     m, Base, Mid, Leaf = inheritance_chain
 
@@ -135,7 +130,7 @@ def test_recalc_on_override_delete_deeper_sub(inheritance_chain):
     del Mid.mult
 
     assert Leaf._impl.own_refs["mult"].interface == 2   # ref re-derived
-    assert Leaf.foo(3) == 6                             # stale: still 9
+    assert Leaf.foo(3) == 6
 
 
 def test_recalc_on_global_ref_change():


### PR DESCRIPTION
## What

Phase 4 of the core refactoring ([devnotes/CoreRefactorDesign.md](https://github.com/fumitoh/modelx/blob/main/devnotes) §5.4, §5.8, §7): the unified mutation pipeline skeleton, with the reference mutations routed through it end-to-end. This is the deliberately small "template phase" that Phases 5 (cells/space ops) and 6 (graph mutations) build on.

- **`modelx/core/edit/transaction.py`** — `Transaction`, a reverse-replay undo journal over container writes (`set_item`/`del_item`/`move_to_end`/`set_attr`/`add_undo`) that restores dict *ordering* bit-identically on rollback, and `ChangeSet` (created/removed/modified, insertion-ordered dirty containers/spaces, registry directives). `Instruction`/`InstructionList` remain for the SpaceUpdater paths.
- **`modelx/core/edit/pipeline.py`** — `ModelEditor` runs each `Edit` through validate → apply → derive inside a `Transaction`, rolls back on any exception, and performs all side effects post-commit in `_finalize`: trace invalidation, deletions, batched notify (exactly one `NamespaceServer.on_notify` per dirty container, replacing the per-mutation `on_notify` calls and the `yield_spaces` loops), ValueRegistry/IOSpec bookkeeping, itemspace invalidation. Edits: `NewRef`/`ChangeRef`/`DelRef` plus model-global counterparts. `Edit.derive` is the interim home of the derived-member fan-out until Phase 5's `InheritanceSync`.
- **`modelx/core/itemspaces.py`** — `ItemSpaceManager` carries the nuke-all invalidation policy verbatim from `DynamicBase.on_notify` (which stays for the not-yet-migrated mutation paths); Phase 7 makes it selective.
- `SpaceManager.new_ref/change_ref/del_ref` and `ModelImpl.new_ref/change_ref/del_ref` become facades constructing Edits — signatures preserved, with new optional `register`/`rebind`/`unregister` keywords carrying the registry directives set by `set_attr`/`del_attr`/`del_ref`.
- `UserSpaceImpl.on_inherit`, `CellsImpl.on_inherit`, `ReferenceImpl.on_inherit` gain a `txn` parameter (§5.6): txn branches journal writes, defer trace/notify effects to finalize, and skip no-op rebinds so unaffected members keep their caches. `DelRef.derive` mirrors `update_subs`, preserving the two-phase inherit order.
- `ReferenceImpl` loses the `set_item` constructor self-registration (D-11; every caller already passed `False`). Dead methods deleted: `on_create_ref`, `on_change_ref`, `change_dynsub_refs` (unreachable at runtime; the last contained a latent `dict.set_item` AttributeError).

## Why

Fixes the scattered per-mutation notification/trace/registry call sites (problem 3 in the design doc) and gives reference edits real transactional rollback, while establishing the pipeline pattern the higher-risk phases reuse.

## Reviewer notes

- **Intentional behavior change (design-predicted):** the Phase 0 strict-xfail `test_recalc_on_override_delete_deeper_sub` now passes and was flipped to a regular test — batched notify marks rebound refs' containers dirty (ref values are baked into `ns_dict`), fixing the stale namespace after a mid-chain override deletion. Relatedly, rebinds that change nothing (identity-compared) no longer clear dependent caches.
- **Preserved quirks**, reproduced deliberately for behavior parity: the `break`-not-`continue` fan-out semantics, the cross-iteration `value` reassignment in the relative-resolution loops, and `change_ref` writing the computed `is_relative` onto the *replaced* ref object (now journaled so rollback restores it).
- `model.editor` / `model.itemspacemgr` are stateless per-access properties — no new slots enter pickled model state.
- Pre-existing bug found during parity testing (unchanged by this PR, tracked separately): `del space.derived_ref` raises `ValueError` from `ValueRegistry.unregister` on main and on this branch alike.
- Full suite: **1060 passed, 6 skipped, 2 xfailed** (the Phase 6 `add_bases` atomicity pair). New unit tests for the journal in `modelx/tests/core/edit/test_transaction.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
