### PR TITLE
MAINT: Add cells and space edit pipeline with InheritanceSync (Phase 5)

### DIFF
--- a/modelx/core/cells.py
+++ b/modelx/core/cells.py
@@ -17,7 +17,7 @@ from collections.abc import Mapping, Callable, Sequence
 from itertools import combinations
 
 from modelx.core.base import (
-    Impl, Derivable, Interface, get_mixin_slots, _rename_item
+    Impl, Derivable, Interface, get_mixin_slots
 )
 from modelx.core.execution.trace import (
     OBJ, KEY, get_node, get_node_repr, tuplize_key, key_to_node
@@ -662,8 +662,10 @@ class CellsImpl(*_cells_impl_base):
 
     def __init__(
         self, *, space, name=None, formula=None, data=None, base=None,
-        is_derived=False, add_to_space=True, is_cached=True, edit_source=True
+        is_derived=False, is_cached=True, edit_source=True
     ):
+        # Side-effect-free w.r.t. the parent's cells container (D-11):
+        # the caller registers self into ``space.cells``.
         formula_temp = None
         use_func_name = False
         # Determine name
@@ -691,35 +693,40 @@ class CellsImpl(*_cells_impl_base):
         )
         Derivable.__init__(self, is_derived)
 
-        if add_to_space:    # Assign to space before calling AlteredFunction.__init__ to avoid getting notified
-            space.cells[name] = self
-            space.on_notify(space.cells)
-
         AlteredFunction.__init__(self, space)
 
-        # Set formula
-        if base:
-            self.formula = base.formula
-        elif formula is None:
-            self.formula = NullFormula(NULL_FORMULA, name=name)
-        elif isinstance(formula, Formula):
-            self.formula = formula.__class__(formula, name=name)
-        elif use_func_name:
-            self.formula = formula_temp
-        else:
-            self.formula = Formula(formula, name=name, edit_source=edit_source)
+        try:
+            # Set formula
+            if base:
+                self.formula = base.formula
+            elif formula is None:
+                self.formula = NullFormula(NULL_FORMULA, name=name)
+            elif isinstance(formula, Formula):
+                self.formula = formula.__class__(formula, name=name)
+            elif use_func_name:
+                self.formula = formula_temp
+            else:
+                self.formula = Formula(
+                    formula, name=name, edit_source=edit_source)
 
-        if base:
-            self.is_cached = base.is_cached
-        else:
-            self.is_cached = is_cached
+            if base:
+                self.is_cached = base.is_cached
+            else:
+                self.is_cached = is_cached
 
-        # Set data
-        self.data = {}
-        if data is None:
-            data = {}
-        self.data.update(data)
-        self.input_keys = set(data.keys())
+            # Set data
+            self.data = {}
+            if data is None:
+                data = {}
+            self.data.update(data)
+            self.input_keys = set(data.keys())
+        except BaseException:
+            # Formula parsing can fail here; a half-built cells must not
+            # stay registered as an observer of the space (the caller's
+            # rollback journals the deregistration only after this
+            # constructor returns).
+            space.remove_observer(self)
+            raise
 
     def on_notify(self, namespace):
         AlteredFunction.on_notify(self, namespace)
@@ -764,11 +771,20 @@ class CellsImpl(*_cells_impl_base):
             # finalize stage and skipped when nothing changed. The
             # namespace entry (the bound ``call``) is unaffected by an
             # in-place rebind, so no container is marked dirty.
+            old_is_cached = self.is_cached
             txn.set_attr(self, "formula", bases[0].formula)
             txn.set_attr(self, "allow_none", bases[0].allow_none)
             txn.set_attr(self, "is_cached", bases[0].is_cached)
             txn.set_attr(self, "is_altfunc_updated", False)
-            txn.add_modified(self)
+            if old_is_cached != bases[0].is_cached:
+                # The deferred clear must dispatch on the pre-edit flag:
+                # clear_obj selects the graph to clear by is_cached, and
+                # the values were recorded under the old flag.
+                model = self.model
+                txn.changes.finalize_ops.append(
+                    lambda: model.clear_obj(self, is_cached=old_is_cached))
+            else:
+                txn.add_modified(self)
 
     @property
     def doc(self):
@@ -927,12 +943,11 @@ class UserCellsImpl(CellsImpl):
 
     def __init__(
         self, space, name=None, formula=None, data=None, base=None,
-        is_derived=False, add_to_space=True,
-        is_cached=True, edit_source=True
+        is_derived=False, is_cached=True, edit_source=True
     ):
         CellsImpl.__init__(
             self, space=space, name=name, formula=formula, data=data,
-            base=base, is_derived=is_derived, add_to_space=add_to_space,
+            base=base, is_derived=is_derived,
             is_cached=is_cached, edit_source=edit_source
         )
 
@@ -959,54 +974,67 @@ class UserCellsImpl(CellsImpl):
 
         self.spmgr.set_cells_formula(self, funcdef)
 
-    def on_rename(self, name):
+    def on_rename(self, name, txn):
         """Renames the Cells name
 
-        - Clears DynamicCells of self
-        - Updates the parent namespace
-        - Clears successors
-            - Clears DynamicCells of self
-        - Renames sub Cells (Repeats the above for the sub Cells)
+        Writes are journaled through ``txn``; trace clearing is deferred
+        to the pipeline finalize stage via the modified list.
         """
-        self.model.clear_obj(self)
         old_name = self.name
-        self.name = name
+        txn.set_attr(self, "name", name)
 
         # Change function name
         if not self.formula._is_lambda:
             if self.is_derived():
                 base = self.bases[0]
-                self.formula = base.formula
+                txn.set_attr(self, "formula", base.formula)
             else:
-                self.formula = Formula(self.formula, name=name)
+                txn.set_attr(self, "formula", Formula(self.formula, name=name))
 
-            self.is_altfunc_updated = False
+            txn.set_attr(self, "is_altfunc_updated", False)
 
-        _rename_item(self.parent.cells, old_name, name)
+        txn.rename_item(self.parent.cells, old_name, name)
+        txn.add_modified(self)
 
-    def on_set_property(self, flags, define, func, enable_cache):
-        """Set formula and/or is_cached"""
+    def on_set_property(self, flags, define, func, enable_cache, txn):
+        """Set formula and/or is_cached
 
-        self.model.clear_obj(self)
+        Writes are journaled through ``txn``; trace clearing is deferred
+        to the pipeline finalize stage via the modified list — except
+        when ``is_cached`` flips, where the deferred clear must dispatch
+        on the pre-edit flag (``clear_obj`` selects the graph to clear
+        by ``is_cached``, and the values were recorded under the old
+        flag), so it is queued explicitly with that flag instead.
+        """
+        cleared = False
 
         if self.is_derived() and define:
-            self.set_defined()
+            txn.set_attr(self, "_is_derived", False)    # set_defined
 
         if flags & self.PROP_FORMULA:
 
             if isinstance(func, NullFormula):
-                self.formula = NULL_FORMULA
+                txn.set_attr(self, "formula", NULL_FORMULA)
             else:
                 if isinstance(func, Formula):
                     cls = func.__class__
                 else:
                     cls = Formula
-                self.formula = cls(func, name=self.name)
+                txn.set_attr(self, "formula", cls(func, name=self.name))
 
-            self.is_altfunc_updated = False
+            txn.set_attr(self, "is_altfunc_updated", False)
 
         if flags & self.PROP_CACHE:
-            self.is_cached = enable_cache
+            old_is_cached = self.is_cached
+            if old_is_cached != enable_cache:
+                model = self.model
+                txn.changes.finalize_ops.append(
+                    lambda: model.clear_obj(self, is_cached=old_is_cached))
+                cleared = True
+            txn.set_attr(self, "is_cached", enable_cache)
+
+        if not cleared:
+            txn.add_modified(self)
 
 
 class DynamicCellsImpl(CellsImpl):

--- a/modelx/core/edit/pipeline.py
+++ b/modelx/core/edit/pipeline.py
@@ -12,7 +12,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unified mutation pipeline (CoreRefactorDesign §5.4, Phase 4).
+"""Unified mutation pipeline (CoreRefactorDesign §5.4, Phases 4-5).
 
 One ``ModelEditor`` entry point runs each ``Edit`` through
 validate -> apply -> derive inside a :class:`Transaction`, rolls back on
@@ -20,16 +20,19 @@ any exception, and performs all side effects (trace invalidation,
 deletions, batched namespace notification, ValueRegistry/IOSpec
 bookkeeping, itemspace invalidation) post-commit in ``_finalize``.
 
-Phase 4 covers the reference mutations end-to-end. The ``derive`` stage
-is an interim per-Edit hook: Phase 5 replaces it with
-``InheritanceSync.derive`` as the single home of derived-member
-creation.
+Phase 4 covered the reference mutations end-to-end; Phase 5 adds the
+cells and non-graph space mutations. The ``derive`` stages delegate to
+``InheritanceSync`` (``inheritance/sync.py``), the single home of
+derived-member creation.
 """
 
-from modelx.core.base import Interface
 from modelx.core.binding.namespace import NamespaceServer
 from modelx.core.reference import ReferenceImpl
+from modelx.core.cells import CellsImpl, UserCellsImpl
+from modelx.core.space import UserSpaceImpl
+from modelx.core.util import is_valid_name
 from modelx.core.edit.transaction import Transaction, ChangeSet
+from modelx.core.inheritance.sync import create_ref, replace_ref
 
 
 class Edit:
@@ -96,6 +99,11 @@ class ModelEditor:
         for impl in changes.removed:
             impl.on_delete()
 
+        # 2.5 Edit-specific post-commit operations (e.g. RenameSpace's
+        #     recursive value clearing)
+        for op in changes.finalize_ops:
+            op()
+
         # 3. Batched notify: exactly one namespace invalidation per
         #    dirty container. The itemspace-deletion half of
         #    DynamicBase.on_notify is handled by ItemSpaceManager below.
@@ -126,23 +134,6 @@ class ModelEditor:
 # Space-level reference edits
 
 
-def _create_ref(txn, space, name, value, is_derived, refmode):
-    ref = ReferenceImpl(space, name, value, container=space.own_refs,
-                        is_derived=is_derived, refmode=refmode)
-    txn.set_item(space.own_refs, name, ref)
-    txn.add_created(ref)
-    txn.mark_dirty(space, "own_refs")
-    return ref
-
-
-def _replace_ref(txn, space, name, value, is_derived, refmode):
-    old = space.own_refs[name]
-    txn.del_item(space.own_refs, name)
-    txn.add_removed(old)
-    new = _create_ref(txn, space, name, value, is_derived, refmode)
-    return old, new
-
-
 class NewRef(Edit):
     """Create a reference in a space and derive it into sub spaces."""
 
@@ -166,28 +157,15 @@ class NewRef(Edit):
             self.space, self.name, self.value, self.refmode)
 
     def apply(self, model, txn):
-        ref = _create_ref(txn, self.space, self.name, self.value,
-                          is_derived=False, refmode=self.refmode)
+        ref = create_ref(txn, self.space, self.name, self.value,
+                         is_derived=False, refmode=self.refmode)
         if self.register:
             txn.changes.registry_ops.append(("register", ref))
         self.result = ref
 
     def derive(self, model, txn):
-        spmgr = model.spmgr
-        space, name, refmode = self.space, self.name, self.refmode
-        value = self.value
-
-        for subspace in spmgr._get_subs(space):
-            is_relative = False
-            if name in subspace.own_refs:
-                break
-            if isinstance(value, Interface) and value._is_valid():
-                if refmode == "auto" or refmode == "relative":
-                    is_relative, value = spmgr.get_relative_interface(
-                        subspace, space.own_refs[name])
-            ref = _create_ref(txn, subspace, name, value,
-                              is_derived=True, refmode=refmode)
-            ref.is_relative = is_relative
+        model.spmgr.sync.derive_new_ref(
+            self.space, self.name, self.value, self.refmode, txn)
 
 
 class ChangeRef(Edit):
@@ -205,35 +183,14 @@ class ChangeRef(Edit):
             self.space, self.name, self.value, self.refmode)
 
     def apply(self, model, txn):
-        old, new = _replace_ref(txn, self.space, self.name, self.value,
-                                is_derived=False, refmode=self.refmode)
+        old, new = replace_ref(txn, self.space, self.name, self.value,
+                               is_derived=False, refmode=self.refmode)
         if self.rebind:
             txn.changes.registry_ops.append(("rebind", old, new))
 
     def derive(self, model, txn):
-        spmgr = model.spmgr
-        space, name, refmode = self.space, self.name, self.refmode
-        value = self.value
-
-        for subspace in spmgr._get_subs(space):
-            is_relative = False
-            subref = subspace.own_refs[name]
-            if subref.is_defined():
-                break
-            elif subref.defined_bases[0] is not space.own_refs[name]:
-                break
-            if isinstance(value, Interface) and value._is_valid():
-                if refmode == "auto" or refmode == "relative":
-                    is_relative, value = spmgr.get_relative_interface(
-                        subspace, space.own_refs[name])
-            old, _ = _replace_ref(txn, subspace, name, value,
-                                  is_derived=True, refmode=refmode)
-            # Preserved pre-pipeline behavior: SpaceManager.change_ref
-            # assigned the resolved is_relative to the object returned by
-            # on_change_ref, which was the replaced (old) ref; the new
-            # derived ref keeps the flag its constructor derives from
-            # refmode.
-            txn.set_attr(old, "is_relative", is_relative)
+        model.spmgr.sync.derive_change_ref(
+            self.space, self.name, self.value, self.refmode, txn)
 
 
 class DelRef(Edit):
@@ -253,14 +210,232 @@ class DelRef(Edit):
             txn.changes.registry_ops.append(("unregister", ref))
 
     def derive(self, model, txn):
-        # Mirrors SharedSpaceOperations.update_subs(space, skip_self=False):
-        # reconcile 'cells' across all affected spaces before 'own_refs'
-        # (the two-phase inheritance order, CoreRefactorDesign §2.1).
+        model.spmgr.sync.derive_subs(self.space, txn, skip_self=False)
+
+
+# ----------------------------------------------------------------------
+# Cells edits
+
+
+class NewCells(Edit):
+    """Create a cells in a space and derive it into sub spaces."""
+
+    def __init__(self, space, name=None, formula=None, data=None,
+                 is_derived=False, is_cached=True, edit_source=True):
+        self.space = space
+        self.name = name
+        self.formula = formula
+        self.data = data
+        self.is_derived = is_derived
+        self.is_cached = is_cached
+        self.edit_source = edit_source
+
+    def validate(self, model, txn):
+        # FIX: Creating a Cells of the same name in ``space``
+        if not model.spmgr._can_add(self.space, self.name, CellsImpl):
+            raise ValueError("Cannot create cells '%s'" % self.name)
+
+    def apply(self, model, txn):
+        space = self.space
+        cells = UserCellsImpl(
+            space=space, name=self.name, formula=self.formula,
+            data=self.data, is_derived=self.is_derived,
+            is_cached=self.is_cached, edit_source=self.edit_source)
+        # The constructor registered the cells as an observer of the
+        # space; undo that on rollback.
+        txn.add_undo(space.remove_observer, cells)
+        txn.set_item(space.cells, cells.name, cells)
+        txn.add_created(cells)
+        txn.mark_dirty(space, "cells")
+        self.result = cells
+
+    def derive(self, model, txn):
+        model.spmgr.sync.derive_new_cells(self.space, self.result, txn)
+
+
+class CopyCells(NewCells):
+    """Create a copy of ``source`` in a space of the same model."""
+
+    def __init__(self, space, source, name=None):
+        if name is None:
+            name = source.name
+        data = {k: v for k, v in source.data.items()
+                if k in source.input_keys}
+        NewCells.__init__(self, space, name=name, formula=source.formula,
+                          data=data, is_derived=False)
+
+
+class DelCells(Edit):
+    """Delete a cells from a space and re-derive its sub spaces."""
+
+    def __init__(self, space, name):
+        self.space = space
+        self.name = name
+
+    def validate(self, model, txn):
+        cells = self.space.cells[self.name]
+        if cells.is_derived():
+            raise ValueError("cannot delete derived")
+
+    def apply(self, model, txn):
+        cells = self.space.cells[self.name]
+        txn.del_item(self.space.cells, self.name)
+        txn.add_removed(cells)
+        txn.mark_dirty(self.space, "cells")
+
+    def derive(self, model, txn):
+        model.spmgr.sync.derive_subs(self.space, txn, skip_self=False)
+
+
+class RenameCells(Edit):
+    """Rename a defined cells and its derived cells in sub spaces."""
+
+    def __init__(self, cells, name):
+        self.cells = cells
+        self.name = name
+
+    def validate(self, model, txn):
+        if not is_valid_name(self.name):
+            raise ValueError("name '%s' is invalid" % self.name)
+
+        if not model.spmgr._can_add(self.cells.parent, self.name, CellsImpl):
+            raise ValueError("cannot create cells '%s'" % self.name)
+
+        if self.cells.bases:
+            raise ValueError("'%s' is a sub Cells of '%s'" % (
+                self.cells.get_repr(fullname=True, add_params=False),
+                self.cells.bases[0].get_repr(
+                    fullname=True, add_params=False)))
+
+    def apply(self, model, txn):
+        old_name = self.cells.name
+        for space in model.spmgr._get_subs(self.cells.parent,
+                                           skip_self=False):
+            txn.add_cleared_subs(space)
+            space.cells[old_name].on_rename(self.name, txn)
+
+
+class SetCellsProperty(Edit):
+    """Set formula and/or is_cached on a cells and its derived cells."""
+
+    def __init__(self, cells, flags, func, enable_cache):
+        self.cells = cells
+        self.flags = flags
+        self.func = func
+        self.enable_cache = enable_cache
+
+    def apply(self, model, txn):
         spmgr = model.spmgr
-        for attr in ("cells", "own_refs"):
-            for s in spmgr._get_subs(self.space, skip_self=False):
-                bases = spmgr._get_space_bases(s)
-                s.on_inherit(spmgr, bases, attr, txn=txn)
+        cells = self.cells
+        define = True
+        for space in spmgr._get_subs(cells.parent, skip_self=False):
+            c = space.cells[cells.name]
+            if (c is not cells and c.is_defined() and
+                    spmgr.get_deriv_bases(c, defined_only=True)[0] is cells):
+                continue   # Skip when c's base is not cells
+            txn.add_cleared_subs(space)
+            space.cells[cells.name].on_set_property(
+                self.flags, define, self.func, self.enable_cache, txn
+            )
+            define = False  # Do not define derived cells
+
+
+class SortCells(Edit):
+    """Sort cells in a space and its sub spaces.
+
+    - Applies only to defined UserSpaces
+    - Only cells defined in the space (neither derived/overridden)
+      are sorted and placed before the derived/overridden cells.
+    - Derived/overridden cells in the sub spaces are also sorted.
+    """
+
+    def __init__(self, space):
+        self.space = space
+
+    def apply(self, model, txn):
+        space = self.space
+        for c in space.cells.values():
+            txn.add_modified(c)
+        for subspace in model.spmgr._get_subs(space, skip_self=False):
+            txn.sort_items(subspace.cells,
+                           self._sorted_keys(subspace, space))
+
+    @staticmethod
+    def _sorted_keys(subspace, space):
+        if subspace.bases:
+
+            # Select names in space but not in space's bases
+
+            bases = [subspace] + list(subspace.bases)
+            while True:
+                if bases.pop(0) is space:
+                    break
+
+            keys = list(space.cells)
+            d = {}
+            for b in bases:
+                d.update(b.cells)
+
+            for k in d:
+                try:
+                    keys.remove(k)
+                except ValueError:
+                    pass
+
+            return sorted(keys)
+
+        else:
+            assert subspace is space
+            return None
+
+
+# ----------------------------------------------------------------------
+# Non-graph space edits
+
+
+class RenameSpace(Edit):
+    """Rename a space, relabeling its node tree in the graph."""
+
+    def __init__(self, space, name):
+        self.space = space
+        self.name = name
+        self._mapping = None
+
+    def validate(self, model, txn):
+        if not model.spmgr._can_add(
+                self.space.parent, self.name, UserSpaceImpl):
+            raise ValueError(
+                "Cannot rename '%s' to '%s'" % (self.space.name, self.name))
+
+        self._mapping = model.spmgr._graph.get_rename_mapping(
+            self.space.idstr, self.name)
+
+    def apply(self, model, txn):
+        space, name = self.space, self.name
+        parent = space.parent
+
+        if not parent.is_model():
+            # Clear parent's dynsub, not space's
+            txn.add_cleared_subs(parent)
+
+        txn.add_modified(space)     # clear_obj in finalize
+        txn.changes.finalize_ops.append(
+            lambda: space.clear_all_cells(
+                clear_input=True, recursive=True, del_items=True))
+
+        old_name = space.name
+        txn.set_attr(space, "name", name)
+        # Pre-pipeline behavior: pop + reassign moves the space to the
+        # end of its parent's container.
+        txn.del_item(parent.named_spaces, old_name)
+        txn.set_item(parent.named_spaces, name, space)
+        if isinstance(parent, NamespaceServer):
+            txn.mark_dirty(parent, "named_spaces")
+
+        graph = model.spmgr._graph
+        inverse = {new: old for old, new in self._mapping.items()}
+        txn.add_undo(graph.relabel, inverse)
+        graph.relabel(self._mapping)
 
 
 # ----------------------------------------------------------------------

--- a/modelx/core/edit/transaction.py
+++ b/modelx/core/edit/transaction.py
@@ -12,6 +12,8 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
+from modelx.core.base import _rename_item, sort_dict
+
 
 class Instruction:
 
@@ -64,6 +66,8 @@ class ChangeSet:
         "modified",
         "dirty_containers",
         "dirty_spaces",
+        "cleared_subs",
+        "finalize_ops",
         "registry_ops"
     )
 
@@ -73,6 +77,15 @@ class ChangeSet:
         self.modified = []          # impls rebound/changed in place
         self.dirty_containers = {}  # (parent_impl, attr) -> None
         self.dirty_spaces = {}      # idstr -> None
+        self.cleared_subs = {}      # space_impl -> None: spaces whose
+                                    # dynamic subs' root itemspaces are
+                                    # cleared selectively in finalize
+                                    # (clear_subs_rootitems), as opposed
+                                    # to the nuke-all policy applied to
+                                    # dirty_containers
+        self.finalize_ops = []      # edit-specific zero-arg callables run
+                                    # post-commit, between deletions and
+                                    # the batched notify
         self.registry_ops = []      # ValueRegistry ops run in finalize:
                                     # ("register", ref) / ("unregister", ref)
                                     # / ("rebind", old_ref, new_ref)
@@ -122,6 +135,16 @@ class Transaction:
         self._journal.append(("move", container, key, index))
         container[key] = container.pop(key)
 
+    def rename_item(self, container, old_key, new_key):
+        """Rename ``old_key`` to ``new_key`` keeping its position."""
+        self._journal.append(("rename", container, old_key, new_key))
+        _rename_item(container, old_key, new_key)
+
+    def sort_items(self, container, sorted_keys=None):
+        """Sort ``container`` keys (all, or the ``sorted_keys`` part)."""
+        self._journal.append(("order", container, list(container)))
+        sort_dict(container, sorted_keys)
+
     def set_attr(self, obj, attr, value):
         self._journal.append(("attr", obj, attr, getattr(obj, attr)))
         setattr(obj, attr, value)
@@ -149,6 +172,10 @@ class Transaction:
         if not parent.is_model():
             self.changes.dirty_spaces[parent.idstr] = None
 
+    def add_cleared_subs(self, space):
+        self.changes.cleared_subs[space] = None
+        self.changes.dirty_spaces[space.idstr] = None
+
     # ----------------------------------------------------------------------
     # Outcome
 
@@ -172,6 +199,13 @@ class Transaction:
                 _, container, key, index = record
                 value = container.pop(key)
                 _insert_at(container, key, value, index)
+            elif kind == "rename":
+                _, container, old_key, new_key = record
+                _rename_item(container, new_key, old_key)
+            elif kind == "order":
+                _, container, keys = record
+                for k in keys:
+                    container[k] = container.pop(k)
             elif kind == "attr":
                 _, obj, attr, old = record
                 setattr(obj, attr, old)

--- a/modelx/core/execution/trace.py
+++ b/modelx/core/execution/trace.py
@@ -191,9 +191,18 @@ class TraceManager:
             self.refgraph.remove_with_referred(n)
             n[OBJ].on_clear_trace(n[KEY])
 
-    def clear_obj(self, obj: TraceObject):
-        """Clear values and nodes of `obj` and their dependants."""
-        if not obj.is_cached:
+    def clear_obj(self, obj: TraceObject, is_cached=None):
+        """Clear values and nodes of `obj` and their dependants.
+
+        ``obj``'s values live in the trace graph when it is cached and in
+        the reference graph when it is not. ``is_cached`` overrides
+        ``obj.is_cached`` for selecting the graph, for callers that flip
+        the flag before a deferred clear (the values were recorded under
+        the pre-flip flag).
+        """
+        if is_cached is None:
+            is_cached = obj.is_cached
+        if not is_cached:
             self.clear_attr_referrers(obj)
             return
 

--- a/modelx/core/inheritance/graph.py
+++ b/modelx/core/inheritance/graph.py
@@ -159,6 +159,21 @@ class SpaceGraph(nx.DiGraph):
     def to_space(self, node):
         return self.nodes[node]["space"]
 
+    def get_rename_mapping(self, node, name):
+        """Map ``node`` and its child tree to their names after renaming
+        ``node``'s last component to ``name``. Pure; does not mutate."""
+        mapping = {}
+        old_id = tuple(node.split("."))
+        new_id = old_id[:-1] + (name,)
+        for child in self.visit_tree(node, include_self=True):
+            old_child = tuple(child.split("."))
+            assert old_id == old_child[:len(old_id)]
+            mapping[child] = ".".join(new_id + old_child[len(new_id):])
+        return mapping
+
+    def relabel(self, mapping):
+        nx.relabel_nodes(self, mapping, copy=False)
+
     def get_relative(self, subspace, basespace, basevalue):
 
         shared_parent = get_shared_asc(basespace, basevalue)

--- a/modelx/core/inheritance/manager.py
+++ b/modelx/core/inheritance/manager.py
@@ -22,15 +22,27 @@ from modelx.core.base import (
     Derivable,
     null_impl
 )
-from modelx.core.cells import CellsImpl, UserCellsImpl
+from modelx.core.cells import UserCellsImpl
 from modelx.core.parent import EditableParentImpl
 from modelx.core.space import UserSpaceImpl
 from modelx.core.binding.namespace import NamespaceServer
 from modelx.core.formula import NULL_FORMULA
 from modelx.core.util import is_valid_name
 from modelx.core.inheritance.graph import SpaceGraph, split_node
+from modelx.core.inheritance.sync import InheritanceSync
 from modelx.core.edit.transaction import Instruction, InstructionList
-from modelx.core.edit.pipeline import NewRef, ChangeRef, DelRef
+from modelx.core.edit.pipeline import (
+    NewRef,
+    ChangeRef,
+    DelRef,
+    NewCells,
+    CopyCells,
+    DelCells,
+    RenameCells,
+    SetCellsProperty,
+    SortCells,
+    RenameSpace,
+)
 
 
 class SharedSpaceOperations:
@@ -38,6 +50,13 @@ class SharedSpaceOperations:
     def __init__(self, model):
         self.model = model
         self._graph = SpaceGraph()
+
+    @property
+    def sync(self):
+        """Derived-member synchronization over this operation's graph
+        (CoreRefactorDesign §5.6). Stateless, so it is constructed per
+        access instead of adding a slot to pickled model state."""
+        return InheritanceSync(self)
 
     def _can_add(self, parent, name, klass):
         """Check name conflict for a given name.
@@ -102,13 +121,6 @@ class SharedSpaceOperations:
         preds = self._graph.ordered_preds(node)
         return [self._graph.to_space(n) for n in preds]
 
-    def update_subs(self, space, skip_self=True):
-
-        for attr in ("cells", "own_refs"):
-            for s in self._get_subs(space, skip_self):
-                b = self._get_space_bases(s, self._graph)
-                s.on_inherit(self, b, attr)
-
     def _get_subs(self, space, skip_self=True):
         idx = 1 if skip_self else 0
         return [
@@ -137,40 +149,10 @@ class SharedSpaceOperations:
 class SpaceManager(SharedSpaceOperations):
 
     def rename_space(self, space, name):
-
-        # Check name does not exit already
-        parent = space.parent
-        if not self._can_add(
-                parent, name, UserSpaceImpl):
-            raise ValueError("Cannot rename '%s' to '%s'" % (space.name, name))
-
-        # Create name mapping
-        mapping = {}
-        old_id = tuple(space.idstr.split("."))
-        new_id = old_id[:-1] + (name,)
-        for node in self._graph.visit_tree(
-                space.idstr, include_self=True):
-
-            old_child = tuple(node.split("."))
-            assert old_id == old_child[:len(old_id)]
-            mapping[node] = ".".join(new_id + old_child[len(new_id):])
-
-        if not space.parent.is_model():
-            # Clear parent's dynsub, not s's
-            space.parent.clear_subs_rootitems()
-
-        # Call on_rename callbacks
-        space.on_rename(name)
-
-        # Rename nodes
-        nx.relabel_nodes(self._graph, mapping, copy=False)
+        self.model.editor.execute(RenameSpace(space, name))
 
     def del_cells(self, space, name):
-        cells = space.cells[name]
-        if cells.is_derived():
-            raise ValueError("cannot delete derived")
-        space.on_del_cells(name)
-        self.update_subs(space, skip_self=False)
+        self.model.editor.execute(DelCells(space, name))
 
     def del_ref(self, space, name, unregister=False):
         self.model.editor.execute(
@@ -178,42 +160,10 @@ class SpaceManager(SharedSpaceOperations):
 
     def new_cells(self, space, name=None, formula=None, data=None,
                   is_derived=False, is_cached=True, edit_source=True):
-
-        # FIX: Creating a Cells of the same name in ``space``
-
-        if not self._can_add(space, name, CellsImpl):
-            raise ValueError("Cannot create cells '%s'" % name)
-
-        cells = UserCellsImpl(
-            space=space, name=name, formula=formula,
-            data=data, is_derived=is_derived, is_cached=is_cached, edit_source=edit_source)
-        space.clear_subs_rootitems()
-
-        name = cells.name   # If name is none, auto-named in __init__
-
-        for subspace in self._get_subs(space):
-            if name in subspace.cells:
-                continue
-            else:
-                subspace.clear_subs_rootitems()
-                derived = UserCellsImpl(
-                    space=subspace,
-                    base=cells, is_derived=True, add_to_space=False,
-                    is_cached=is_cached
-                )
-                base_cells = {}
-                for b in reversed(subspace.bases):
-                    base_cells.update(b.cells)
-
-                idx = list(base_cells).index(name)
-                cells_after = list(subspace.cells)[idx:]
-                subspace.cells[name] = derived
-                subspace.on_notify(subspace.cells)
-
-                for k in cells_after:
-                    subspace.cells[k] = subspace.cells.pop(k)
-
-        return cells
+        return self.model.editor.execute(NewCells(
+            space, name=name, formula=formula, data=data,
+            is_derived=is_derived, is_cached=is_cached,
+            edit_source=edit_source))
 
     def copy_cells(self, space: UserSpaceImpl,
                    source: UserCellsImpl, name=None):
@@ -222,31 +172,11 @@ class SpaceManager(SharedSpaceOperations):
         if space.model is not self.model:
             return space.spmgr.copy_cells(space, source, name)
 
-        if name is None:
-            name = source.name
-
-        data = {k: v for k, v in source.data.items() if k in source.input_keys}
-        return self.new_cells(space, name=name, formula=source.formula,
-                       data=data, is_derived=False)
+        return self.model.editor.execute(CopyCells(space, source, name))
 
     def rename_cells(self, cells, name):
         """Renames the Cells name"""
-        if not is_valid_name(name):
-            raise ValueError("name '%s' is invalid" % name)
-
-        if not self._can_add(cells.parent, name, CellsImpl):
-            raise ValueError("cannot create cells '%s'" % name)
-
-        if cells.bases:
-            raise ValueError("'%s' is a sub Cells of '%s'" % (
-                cells.get_repr(fullname=True, add_params=False),
-                cells.bases[0].get_repr(fullname=True, add_params=False)))
-
-        old_name = cells.name
-
-        for space in self._get_subs(cells.parent, skip_self=False):
-            space.clear_subs_rootitems()
-            space.cells[old_name].on_rename(name)
+        self.model.editor.execute(RenameCells(cells, name))
 
     def sort_cells(self, space):
         """Sort cells in a space
@@ -256,22 +186,12 @@ class SpaceManager(SharedSpaceOperations):
           are sorted and placed before the derived/overridden cells.
         - Derived/overridden cells in the sub spaces are also sorted.
         """
-        for subspace in self._get_subs(space, skip_self=False):
-            subspace.on_sort_cells(space=space)
+        self.model.editor.execute(SortCells(space))
 
     def set_cells_property(self, cells, flags, func, enable_cache):
         """Set formula and/or is_enabled"""
-        define = True
-        for space in self._get_subs(cells.parent, skip_self=False):
-            c = space.cells[cells.name]
-            if (c is not cells and c.is_defined() and
-                    self.get_deriv_bases(c, defined_only=True)[0] is cells):
-                continue   # Skip when c's base is not cells
-            space.clear_subs_rootitems()
-            space.cells[cells.name].on_set_property(
-                flags, define, func, enable_cache
-            )
-            define = False  # Do not define derived cells
+        self.model.editor.execute(
+            SetCellsProperty(cells, flags, func, enable_cache))
 
     def set_cells_formula(self, cells, func):
         self.set_cells_property(cells, UserCellsImpl.PROP_FORMULA, func, True)
@@ -342,7 +262,7 @@ class SpaceUpdater(SharedSpaceOperations):
     def _update_derived_space(self, node):
         space = self._graph.to_space(node)
         bases = self._get_space_bases(space, self._graph)
-        space.on_inherit(self, bases, 'cells')
+        self.sync.reconcile(space, bases, 'cells')
         self._instructions.append(
             Instruction(self._update_derived_refs, (node,))
         )
@@ -350,7 +270,7 @@ class SpaceUpdater(SharedSpaceOperations):
     def _update_derived_refs(self, node):
         space = self._graph.to_space(node)
         bases = self._get_space_bases(space, self._graph)
-        space.on_inherit(self, bases, 'own_refs')
+        self.sync.reconcile(space, bases, 'own_refs')
 
     def _remove_hook(self, graph, node):
 

--- a/modelx/core/inheritance/sync.py
+++ b/modelx/core/inheritance/sync.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
+
+# This library is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation version 3.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Inheritance synchronization (CoreRefactorDesign §5.6, Phase 5).
+
+:class:`InheritanceSync` is the only place derived members are created,
+updated or removed. It absorbs what used to be three duplicated code
+paths:
+
+(a) ``UserSpaceImpl.on_inherit``'s member reconciliation loop
+    (:meth:`InheritanceSync.reconcile`),
+(b) the derived-cells fan-out of ``SpaceManager.new_cells`` including
+    the ``cells_after`` reorder (:meth:`InheritanceSync.derive_new_cells`),
+(c) the derived-ref fan-outs of ``new_ref``/``change_ref``
+    (:meth:`derive_new_ref`/:meth:`derive_change_ref`).
+
+Member-level ``CellsImpl.on_inherit``/``ReferenceImpl.on_inherit``
+remain as callbacks invoked from here, with container writes routed
+through the transaction when one is given. Without a transaction the
+methods perform the pre-pipeline immediate writes; this path is used by
+``SpaceUpdater`` until the graph mutations move into the pipeline
+(Phase 6).
+"""
+
+from modelx.core.base import Interface
+from modelx.core.chainmap import CustomChainMap
+from modelx.core.cells import UserCellsImpl
+from modelx.core.reference import ReferenceImpl
+
+
+def create_ref(txn, space, name, value, is_derived, refmode):
+    """Create a reference in ``space`` through the transaction."""
+    ref = ReferenceImpl(space, name, value, container=space.own_refs,
+                        is_derived=is_derived, refmode=refmode)
+    txn.set_item(space.own_refs, name, ref)
+    txn.add_created(ref)
+    txn.mark_dirty(space, "own_refs")
+    return ref
+
+
+def replace_ref(txn, space, name, value, is_derived, refmode):
+    """Replace the reference bound to ``name`` through the transaction."""
+    old = space.own_refs[name]
+    txn.del_item(space.own_refs, name)
+    txn.add_removed(old)
+    new = create_ref(txn, space, name, value, is_derived, refmode)
+    return old, new
+
+
+class InheritanceSync:
+    """The single home of derived-member creation (D-8).
+
+    ``ops`` is a ``SharedSpaceOperations`` instance (``SpaceManager`` or
+    ``SpaceUpdater``) providing the graph queries — subs, space bases and
+    relative-interface resolution — against the graph the operation is
+    running on. Stateless: constructed per access by the ``sync``
+    property of ``SharedSpaceOperations``.
+    """
+
+    def __init__(self, ops):
+        self.ops = ops
+
+    # ----------------------------------------------------------------------
+    # Full reconciliation (from UserSpaceImpl.on_inherit)
+
+    def derive_subs(self, space, txn=None, skip_self=True):
+        """Reconcile all subs of ``space`` against their bases.
+
+        Keeps the two-phase inheritance order: all ``cells`` syncs across
+        the affected subgraph run before all ``own_refs`` syncs, so that
+        relative references resolve against derived spaces created in the
+        same edit (CoreRefactorDesign §2.1).
+        """
+        for attr in ("cells", "own_refs"):
+            for s in self.ops._get_subs(space, skip_self):
+                bases = self.ops._get_space_bases(s)
+                self.reconcile(s, bases, attr, txn=txn)
+
+    def reconcile(self, space, bases, attr, txn=None):
+        """Reconcile ``attr`` ('cells' or 'own_refs') of ``space``
+        against ``bases``.
+
+        Derived members missing from ``space`` are created, members no
+        longer backed by a base are removed, and surviving members are
+        reordered to the bases' order and re-derived through their
+        member-level ``on_inherit`` callbacks.
+        """
+        attrs = {
+            "cells": space.on_del_cells,
+            "own_refs": space.on_del_ref
+        }
+
+        selfdict = getattr(space, attr)
+        basedict = CustomChainMap(*[getattr(b, attr) for b in bases])
+        selfkeys = list(selfdict)
+
+        for name in basedict: # ChainMap iterates from the last map
+
+            bs = [bm[name] for bm in basedict.maps
+                  if name in bm and bm[name].is_defined()]
+
+            if name not in selfdict:
+
+                if attr == "cells":
+                    cells = UserCellsImpl(
+                        space=space, name=name, formula=None,
+                        is_derived=True)
+                    if txn is None:
+                        selfdict[name] = cells
+                        space.on_notify(space.cells)
+                    else:
+                        # The constructor registered the cells as an
+                        # observer of space; undo that on rollback.
+                        txn.add_undo(space.remove_observer, cells)
+                        txn.set_item(selfdict, name, cells)
+                        txn.add_created(cells)
+                        txn.mark_dirty(space, attr)
+
+                elif attr == "own_refs":
+                    ref = ReferenceImpl(
+                        space, name, None,
+                        container=space.own_refs,
+                        is_derived=True,
+                        refmode=bs[0].refmode
+                    )
+                    if txn is None:
+                        selfdict[name] = ref
+                    else:
+                        txn.set_item(selfdict, name, ref)
+                        txn.add_created(ref)
+                        txn.mark_dirty(space, attr)
+                else:
+                    raise RuntimeError("must not happen")
+
+            else:
+                # Remove & add back for reorder
+                if txn is None:
+                    selfdict[name] = selfdict.pop(name)
+                else:
+                    txn.move_to_end(selfdict, name)
+                selfkeys.remove(name)
+
+            if selfdict[name].is_derived():
+                selfdict[name].on_inherit(self.ops, bs, txn=txn)
+
+        for name in selfkeys:
+            if selfdict[name].is_derived():
+                if txn is None:
+                    attrs[attr](name)
+                else:
+                    member = selfdict[name]
+                    txn.del_item(selfdict, name)
+                    txn.add_removed(member)
+                    txn.mark_dirty(space, attr)
+            else:   # defined
+                if txn is None:
+                    selfdict[name] = selfdict.pop(name)
+                else:
+                    txn.move_to_end(selfdict, name)
+
+    # ----------------------------------------------------------------------
+    # Member-creation fan-outs (from SpaceManager.new_cells and the
+    # Phase 4 NewRef/ChangeRef derive stages)
+
+    def derive_new_cells(self, space, cells, txn):
+        """Fan a newly defined cells out to the subs of ``space``.
+
+        Each derived cells is inserted at the position ``cells.name``
+        occupies in the union of the sub's bases' cells (the
+        ``cells_after`` reorder).
+        """
+        name = cells.name
+        for subspace in self.ops._get_subs(space):
+            if name in subspace.cells:
+                continue
+            derived = UserCellsImpl(
+                space=subspace, base=cells, is_derived=True)
+            txn.add_undo(subspace.remove_observer, derived)
+
+            base_cells = {}
+            for b in reversed(subspace.bases):
+                base_cells.update(b.cells)
+
+            idx = list(base_cells).index(name)
+            cells_after = list(subspace.cells)[idx:]
+
+            txn.set_item(subspace.cells, name, derived)
+            txn.add_created(derived)
+            txn.mark_dirty(subspace, "cells")
+
+            for k in cells_after:
+                txn.move_to_end(subspace.cells, k)
+
+    def derive_new_ref(self, space, name, value, refmode, txn):
+        """Fan a newly defined reference out to the subs of ``space``."""
+        for subspace in self.ops._get_subs(space):
+            is_relative = False
+            if name in subspace.own_refs:
+                break
+            if isinstance(value, Interface) and value._is_valid():
+                if refmode == "auto" or refmode == "relative":
+                    is_relative, value = self.ops.get_relative_interface(
+                        subspace, space.own_refs[name])
+            ref = create_ref(txn, subspace, name, value,
+                             is_derived=True, refmode=refmode)
+            ref.is_relative = is_relative
+
+    def derive_change_ref(self, space, name, value, refmode, txn):
+        """Fan a reference rebinding out to the subs of ``space``."""
+        for subspace in self.ops._get_subs(space):
+            is_relative = False
+            subref = subspace.own_refs[name]
+            if subref.is_defined():
+                break
+            elif subref.defined_bases[0] is not space.own_refs[name]:
+                break
+            if isinstance(value, Interface) and value._is_valid():
+                if refmode == "auto" or refmode == "relative":
+                    is_relative, value = self.ops.get_relative_interface(
+                        subspace, space.own_refs[name])
+            old, _ = replace_ref(txn, subspace, name, value,
+                                 is_derived=True, refmode=refmode)
+            # Preserved pre-pipeline behavior: SpaceManager.change_ref
+            # assigned the resolved is_relative to the object returned by
+            # on_change_ref, which was the replaced (old) ref; the new
+            # derived ref keeps the flag its constructor derives from
+            # refmode.
+            txn.set_attr(old, "is_relative", is_relative)

--- a/modelx/core/itemspaces.py
+++ b/modelx/core/itemspaces.py
@@ -24,6 +24,11 @@ class ItemSpaceManager:
     fan-out. Phase 7 replaces this with closure-based selective
     invalidation.
 
+    Edits that do not change namespaces (cells formula changes and
+    renames) instead record spaces in ``ChangeSet.cleared_subs``, which
+    applies the selective pre-pipeline ``clear_subs_rootitems`` policy:
+    only the root itemspaces of the space's dynamic subs are cleared.
+
     Stateless: constructed per access by ``ModelImpl.itemspacemgr`` so
     that no new slot enters pickled model state.
     """
@@ -32,6 +37,9 @@ class ItemSpaceManager:
         self.model = model
 
     def invalidate(self, changes):
+        for space in changes.cleared_subs:
+            space.clear_subs_rootitems()
+
         spaces = {}     # dict as insertion-ordered set
         for parent, attr in changes.dirty_containers:
             if parent.is_model():

--- a/modelx/core/space.py
+++ b/modelx/core/space.py
@@ -31,7 +31,6 @@ from modelx.core.base import (
     get_mixin_slots,
     Interface,
     Impl,
-    sort_dict
 )
 from modelx.core.reference import (
     ReferenceImpl,
@@ -59,7 +58,6 @@ from modelx.core.formula import Formula, ModuleSource
 from modelx.core.cells import (
     Cells,
     DynamicCellsImpl,
-    UserCellsImpl,
     shareable_parameters,
 )
 from modelx.core.util import AutoNamer, is_valid_name, get_module
@@ -2412,89 +2410,6 @@ class UserSpaceImpl(*_user_space_impl_base):
         for name in cells_to_update:
             self.cells[name].reload(module=modsrc)
 
-    def on_inherit(self, updater, bases, attr, txn=None):
-        """Reconcile ``attr`` ('cells' or 'own_refs') against ``bases``.
-
-        Without ``txn``: pre-pipeline behavior (immediate writes, used
-        by SpaceUpdater). With ``txn``: container writes are journaled,
-        notification/trace/deletion side effects are deferred to the
-        pipeline finalize stage. Phase 5 absorbs this reconciliation
-        into InheritanceSync.
-        """
-        attrs = {
-            "cells": self.on_del_cells,
-            "own_refs": self.on_del_ref
-        }
-
-        selfdict = getattr(self, attr)
-        basedict = CustomChainMap(*[getattr(b, attr) for b in bases])
-        selfkeys = list(selfdict)
-
-        for name in basedict: # ChainMap iterates from the last map
-
-            bs = [bm[name] for bm in basedict.maps
-                  if name in bm and bm[name].is_defined()]
-
-            if name not in selfdict:
-
-                if attr == "cells":
-                    if txn is None:
-                        selfdict[name] = UserCellsImpl(
-                            space=self, name=name, formula=None,
-                            is_derived=True)
-                    else:
-                        cells = UserCellsImpl(
-                            space=self, name=name, formula=None,
-                            is_derived=True, add_to_space=False)
-                        # The constructor registered the cells as an
-                        # observer of self; undo that on rollback.
-                        txn.add_undo(self.remove_observer, cells)
-                        txn.set_item(selfdict, name, cells)
-                        txn.add_created(cells)
-                        txn.mark_dirty(self, attr)
-
-                elif attr == "own_refs":
-                    ref = ReferenceImpl(
-                        self, name, None,
-                        container=self.own_refs,
-                        is_derived=True,
-                        refmode=bs[0].refmode
-                    )
-                    if txn is None:
-                        selfdict[name] = ref
-                    else:
-                        txn.set_item(selfdict, name, ref)
-                        txn.add_created(ref)
-                        txn.mark_dirty(self, attr)
-                else:
-                    raise RuntimeError("must not happen")
-
-            else:
-                # Remove & add back for reorder
-                if txn is None:
-                    selfdict[name] = selfdict.pop(name)
-                else:
-                    txn.move_to_end(selfdict, name)
-                selfkeys.remove(name)
-
-            if selfdict[name].is_derived():
-                selfdict[name].on_inherit(updater, bs, txn=txn)
-
-        for name in selfkeys:
-            if selfdict[name].is_derived():
-                if txn is None:
-                    attrs[attr](name)
-                else:
-                    member = selfdict[name]
-                    txn.del_item(selfdict, name)
-                    txn.add_removed(member)
-                    txn.mark_dirty(self, attr)
-            else:   # defined
-                if txn is None:
-                    selfdict[name] = selfdict.pop(name)
-                else:
-                    txn.move_to_end(selfdict, name)
-
     def on_del_cells(self, name):
         cells = self.cells[name]
         self.model.clear_obj(cells)
@@ -2502,53 +2417,11 @@ class UserSpaceImpl(*_user_space_impl_base):
         self.on_notify(self.cells)
         cells.on_delete()
 
-    def on_sort_cells(self, space):
-
-        for c in space.cells.values():
-            self.model.clear_obj(c)
-
-        if self.bases:
-
-            # Select names in space but not in space's bases
-
-            bases = [self] + list(self.bases)    # bases lists space's bases
-            while True:
-                if bases.pop(0) is space:
-                    break
-
-            keys = list(space.cells)
-            d = {}
-            for b in bases:
-                d.update(b.cells)
-
-            for k in d:
-                try:
-                    keys.remove(k)
-                except ValueError:
-                    pass
-
-            keys = sorted(keys)
-
-        else:
-            assert self is space
-            keys = None
-
-        sort_dict(self.cells, keys)
-
     def on_del_ref(self, name):
         self.model.clear_attr_referrers(self.own_refs[name])
         self.own_refs[name].on_delete()
         del self.own_refs[name]
         self.on_notify(self.own_refs)
-
-    def on_rename(self, name):
-        self.model.clear_obj(self)
-        self.clear_all_cells(clear_input=True, recursive=True, del_items=True)
-        old_name = self.name
-        self.name = name
-        self.parent.named_spaces[name] = self.parent.named_spaces.pop(old_name)
-        if isinstance(self.parent, NamespaceServer):    # TODO: Refactor
-            self.parent.on_notify(self.parent.named_spaces)
 
 
 class DynamicSpace(BaseSpace):
@@ -2636,7 +2509,9 @@ class DynamicSpaceImpl(BaseSpaceImpl):
 
     def _init_cells(self):
         for base in self._dynbase.cells.values():
-            DynamicCellsImpl(space=self, base=base, is_derived=True)
+            cells = DynamicCellsImpl(space=self, base=base, is_derived=True)
+            self.cells[cells.name] = cells
+            self.on_notify(self.cells)
 
     def _init_refs(self, arguments=None):
         self._allargs = self._init_allargs()

--- a/modelx/tests/core/cells/test_cache.py
+++ b/modelx/tests/core/cells/test_cache.py
@@ -165,3 +165,56 @@ def test_uncached_cells_error(method):
         getattr(foo, method)(0)
 
     m.close()
+
+
+def test_disable_cache_clears_values():
+    """Toggling is_cached off clears the cells' values and dependents
+    recorded in the trace graph, so later formula changes propagate."""
+    m = mx.new_model()
+    s = m.new_space()
+
+    @mx.defcells(space=s)
+    def foo():
+        return 1
+
+    @mx.defcells(space=s)
+    def bar():
+        return foo() + 1
+
+    assert bar() == 2
+
+    foo.is_cached = False
+    assert foo._impl.data == {}
+    assert bar._impl.data == {}
+
+    foo.formula = lambda: 100
+    assert bar() == 101
+
+    m._impl._check_sanity()
+    m.close()
+
+
+def test_enable_cache_clears_values():
+    """Toggling is_cached on clears dependents recorded in the reference
+    graph, so later formula changes propagate."""
+    m = mx.new_model()
+    s = m.new_space()
+
+    @mx.defcells(space=s, is_cached=False)
+    def foo():
+        return 1
+
+    @mx.defcells(space=s)
+    def bar():
+        return foo() + 1
+
+    assert bar() == 2
+
+    foo.is_cached = True
+    assert bar._impl.data == {}
+
+    foo.formula = lambda: 100
+    assert bar() == 101
+
+    m._impl._check_sanity()
+    m.close()

--- a/modelx/tests/core/space/test_new_cells.py
+++ b/modelx/tests/core/space/test_new_cells.py
@@ -3,6 +3,29 @@ from modelx.core.errors import DeletedObjectError
 import pytest
 
 
+def test_new_cells_invalid_formula_rolls_back():
+    """A new_cells whose formula fails to parse leaves the space intact:
+    no leftover cells, no half-built observer breaking later edits."""
+    m = mx.new_model()
+    s = m.new_space("A")
+    s.new_cells(name="good", formula=lambda: 1)
+
+    observers_before = list(s._impl.observers)
+
+    with pytest.raises(SyntaxError):
+        s.new_cells(name="bad", formula="this is not valid python")
+
+    assert list(s._impl.cells) == ["good"]
+    assert s._impl.observers == observers_before
+
+    # Subsequent edits work
+    s.new_cells(name="bar", formula="def bar(): return good() + 1")
+    assert s.bar() == 2
+
+    m._impl._check_sanity()
+    m.close()
+
+
 def test_new_cells_in_dynbase():
     """
         m----Parent----Parent[x]<--Base


### PR DESCRIPTION
Phase 5 of the core refactoring ([devnotes/CoreRefactorDesign.md](https://github.com/fumitoh/modelx/blob/core-refactor-phase5/devnotes/CoreRefactorDesign.md), follows #245): the cells mutations and the non-graph space mutations go through the edit pipeline, and derived-member creation gets a single home.

## What changed

- **`inheritance/sync.py::InheritanceSync`** — the only place derived members are created/updated/removed (D-8). Absorbs the three previously duplicated paths:
  - `UserSpaceImpl.on_inherit`'s reconcile loop → `reconcile` (the `txn=None` immediate-write path remains for `SpaceUpdater` until Phase 6);
  - the derived-cells fan-out of `SpaceManager.new_cells`, including the `cells_after` insert-position reorder → `derive_new_cells`;
  - the derived-ref fan-outs Phase 4 left in `NewRef`/`ChangeRef.derive` → `derive_new_ref`/`derive_change_ref`.

  `derive_subs` keeps the two-phase inheritance order (all `cells` syncs across the affected subgraph before all `own_refs` syncs). Reached via a stateless `sync` property on `SharedSpaceOperations`, so `SpaceUpdater` applies it over its own graph copy and no pickled slot is added.
- **New Edits** `NewCells`, `CopyCells`, `DelCells`, `RenameCells`, `SetCellsProperty`, `SortCells`, `RenameSpace`; the corresponding `SpaceManager` methods become facades (signatures preserved — `parent.py`'s direct `spmgr.new_cells` call and all serializer/api callers are untouched). `update_subs` and the space-level `on_inherit`/`on_sort_cells`/`on_rename` callbacks are absorbed and deleted.
- **`CellsImpl.__init__` loses `add_to_space`** (D-11): the constructor no longer writes into `space.cells` or notifies; registration happens in the pipeline apply stage (or explicitly in `DynamicSpaceImpl._init_cells` on the dynamic path). The constructor tail now deregisters the half-built observer if formula parsing fails, so a failed `new_cells` rolls back to an exactly-intact model (on master the same input corrupts the space).
- **Invalidation granularity preserved** via two new `ChangeSet` fields: `cleared_subs` carries the selective `clear_subs_rootitems` policy (cells formula changes and renames), consumed by `ItemSpaceManager` before the nuke-all dirty-container pass; `finalize_ops` carries edit-specific post-commit actions (RenameSpace's recursive value clearing, is_cached-flip clears). This keeps the heterogeneity pinned by the Phase 0 characterization tests (nuke-at-parent for namespace changes vs selective per dynbase for formula changes).
- **`Transaction`** gains journaled `rename_item` (position-preserving) and `sort_items` (records pre-sort key order); **`SpaceGraph`** gains `get_rename_mapping`/`relabel` so `RenameSpace` journals the inverse node-tree relabel (node-string surgery stays in `graph.py`, D-6).

## Bug found and fixed during review

An adversarial multi-agent review (the suite alone missed this) found that deferring `clear_obj` to the finalize stage broke `Cells.is_cached` toggles: `TraceManager.clear_obj` selects tracegraph-vs-refgraph by `obj.is_cached`, and finalize saw the *new* flag, so nothing was cleared and dependents went silently stale. Fixed by giving `clear_obj` an `is_cached` override and queuing the deferred clear bound to the pre-edit flag (`on_set_property`, and `CellsImpl.on_inherit`'s txn path for base-driven flag changes). The two new regression tests in `test_cache.py` pass on master unmodified, i.e. they characterize the pre-existing behavior this restores.

## Verification

- Full suite: **1063 passed, 6 skipped, 2 xfailed** (the Phase 6 `add_bases` atomicity pair) — counts identical to a fresh main-worktree baseline (1060/6/2 + 3 new tests).
- An 8-scenario behavioral probe (derived fan-out ordering, override-delete re-derivation, rename granularity/itemspace survival, sort ordering, space rename container position, inheritance shielding, validation atomicity, `copy_cells` input filtering) produces byte-identical output on main and this branch.
- Preserved quirks worth knowing as a reviewer: `RenameSpace` still moves the space to the *end* of its parent''s container and clears all values including inputs recursively; cells renames still do not notify namespaces; the `new_cells` same-name overwrite (`FIX` comment) is carried over unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)