### PR TITLE
Improve reference deletion handling and validation

### DIFF
--- a/modelx/core/edit/pipeline.py
+++ b/modelx/core/edit/pipeline.py
@@ -217,12 +217,21 @@ class DelRef(Edit):
         self.name = name
         self.unregister = unregister
 
+    def validate(self, model, txn):
+        ref = self.space.own_refs[self.name]
+        if ref.is_derived():
+            raise ValueError(
+                "cannot delete derived ref '%s'" % self.name)
+
     def apply(self, model, txn):
         ref = self.space.own_refs[self.name]
         txn.del_item(self.space.own_refs, self.name)
         txn.add_removed(ref)
         txn.mark_dirty(self.space, "own_refs")
-        if self.unregister:
+        if self.unregister and model.valreg.is_registered(ref):
+            # Defined refs created by new_space(refs=...) are never
+            # registered, so unconditional unregister would crash
+            # finalize post-commit.
             txn.changes.registry_ops.append(("unregister", ref))
 
     def derive(self, model, txn):

--- a/modelx/core/refs.py
+++ b/modelx/core/refs.py
@@ -109,6 +109,19 @@ class ValueRegistry:
     # ----------------------------------------------------------------------
     # Queries
 
+    def is_registered(self, ref):
+        """Return whether ``ref`` is registered for its value.
+
+        False for refs that never go through the attribute-access
+        paths, such as derived refs and refs created by
+        ``new_space(refs=...)``.
+        """
+        value = ref.interface
+        if isinstance(value, Interface):
+            return False
+        entry = self._entries.get(id(value))
+        return entry is not None and any(r is ref for r in entry.refs)
+
     def has_value(self, value):
         return id(value) in self._entries
 

--- a/modelx/core/space.py
+++ b/modelx/core/space.py
@@ -2433,8 +2433,6 @@ class UserSpaceImpl(*_user_space_impl_base):
 
         if name in self.own_refs:
             self.model.spmgr.del_ref(self, name, unregister=True)
-        elif name in self.is_derived():
-            raise KeyError("Derived ref '%s' cannot be deleted" % name)
         elif name in self.arguments:
             raise ValueError("Argument cannot be deleted")
         elif name in self.sys_refs:

--- a/modelx/tests/core/reference/test_del_ref.py
+++ b/modelx/tests/core/reference/test_del_ref.py
@@ -1,0 +1,49 @@
+import pytest
+import modelx as mx
+
+
+@pytest.fixture
+def testmodel():
+    m = mx.new_model()
+    yield m
+    m._impl._check_sanity()
+    m.close()
+
+
+def test_del_derived_ref_raises(testmodel):
+    """Deleting a derived ref raises ValueError and leaves it intact."""
+    A = testmodel.new_space("A")
+    A.x = 1
+    B = testmodel.new_space("B", bases=A)
+
+    with pytest.raises(ValueError, match="cannot delete derived ref 'x'"):
+        del B.x
+
+    assert B.x == 1
+    assert B._impl.own_refs["x"].is_derived()
+
+
+def test_del_ref_overriding_derived(testmodel):
+    """Deleting a defined override reverts to the inherited ref."""
+    A = testmodel.new_space("A")
+    A.x = 1
+    B = testmodel.new_space("B", bases=A)
+
+    B.x = 5
+    assert B.x == 5
+    assert not B._impl.own_refs["x"].is_derived()
+
+    del B.x
+
+    assert B.x == 1
+    assert B._impl.own_refs["x"].is_derived()
+
+
+def test_del_ref_created_by_new_space(testmodel):
+    """Refs created by new_space(refs=...) are never registered in
+    ValueRegistry but must still be deletable."""
+    C = testmodel.new_space("C", refs={"y": 42})
+
+    del C.y
+
+    assert "y" not in C.refs


### PR DESCRIPTION
## Summary
This PR improves the handling of reference deletion in modelx by adding proper validation, fixing error handling for derived references, and correctly managing unregistration of references that were never registered in the value registry.

## Key Changes

- **Added validation for derived reference deletion**: Implemented a `validate()` method in `DeleteRefOp` that prevents deletion of derived references with a clear error message, replacing the previous flawed check in `del_ref()`.

- **Fixed unregistration logic**: Modified the `apply()` method to only unregister references that are actually registered in the value registry. This prevents crashes when deleting references created via `new_space(refs=...)` which are never registered.

- **Added `is_registered()` method to ValueRegistry**: New query method to determine whether a reference is registered for its value, accounting for special cases like derived references and refs created by `new_space(refs=...)`.

- **Improved error handling**: Moved validation logic from `del_ref()` to the transaction pipeline, providing better separation of concerns and more reliable error checking.

- **Added comprehensive test coverage**: New test file `test_del_ref.py` with three test cases covering:
  - Deletion of derived references (should raise ValueError)
  - Deletion of overridden references (should revert to inherited ref)
  - Deletion of references created via `new_space(refs=...)`

## Implementation Details

The changes follow the transaction-based architecture by implementing validation in the pipeline stage rather than at the API level. This ensures consistency and allows the transaction system to properly handle all edge cases. The fix for unregistration prevents attempting to unregister references that never went through the attribute-access paths.

https://claude.ai/code/session_0135i6isD3tun57gLny7JDUU