### PR TITLE
ENH: Load models tolerantly when pickled values cannot be restored

### DIFF
--- a/modelx/serialize/custom_pickle.py
+++ b/modelx/serialize/custom_pickle.py
@@ -123,15 +123,25 @@ class ModelUnpickler(pickle.Unpickler):
         if reader.version >= 5:
             self.iospecs = reader.iospecs
 
+    def _find_iospec(self, sp_id):
+        # In the fast strict pass the error aborts the load and triggers
+        # the tolerant retry (tolerant_pickle), which catches this in its
+        # persistent_load and substitutes a placeholder.
+        iospecs = getattr(self, "iospecs", None)
+        if isinstance(iospecs, dict) and iospecs.get(sp_id) is not None:
+            return iospecs[sp_id]
+        raise KeyError(
+            "IO spec not found for pickled value (id: %s)" % sp_id)
+
     def persistent_load(self, pid):
 
         if pid[0] == "DataValue":
             _, sp_id = pid
-            return self.iospecs[sp_id].value
+            return self._find_iospec(sp_id).value
 
         elif pid[0] in ("BaseIOSpec", "BaseDataSpec"):  # renamed in v0.20
             _, sp_id = pid
-            return self.iospecs[sp_id]
+            return self._find_iospec(sp_id)
 
         elif pid[0] in ("BaseSharedIO", "BaseSharedData"):  # renamed in v0.20
 

--- a/modelx/serialize/pandas_compat.py
+++ b/modelx/serialize/pandas_compat.py
@@ -9,7 +9,32 @@ from pandas.compat import pickle_compat as pc
 # CompatUnpickler is slower then ModelUnpickler, so
 # Use CompatUpickler only when needed.
 
-class CompatUnpickler(pickle._Unpickler):
+# pandas' own compat unpickler (a pickle._Unpickler subclass): its
+# find_class remaps relocated pandas classes, and on pandas < 3 its
+# dispatch copy binds REDUCE/NEWOBJ to pandas-compat handlers.
+CompatBase = getattr(pc, "Unpickler", None)
+
+if CompatBase is None:
+    # Very old pandas exposing module-level handlers instead
+
+    class CompatBase(pickle._Unpickler):
+
+        def find_class(self, module, name):
+            key = (module, name)
+            module, name = pc._class_locations_map.get(key, key)
+            return super().find_class(module, name)
+
+    CompatBase.dispatch = copy.copy(CompatBase.dispatch)
+    for _opcode, _name in (
+            (pickle.REDUCE, "load_reduce"),
+            (pickle.NEWOBJ, "load_newobj"),
+            (pickle.NEWOBJ_EX, "load_newobj_ex")):
+        _func = getattr(pc, _name, None)
+        if _func is not None:
+            CompatBase.dispatch[_opcode[0]] = _func
+
+
+class CompatUnpickler(CompatBase):
     """Unpickler to fix Pandas incompatibility issue"""
 
     def __init__(self, file, reader):
@@ -21,20 +46,4 @@ class CompatUnpickler(pickle._Unpickler):
             self.iospecs = reader.iospecs
 
     persistent_load = ModelUnpickler.persistent_load
-
-    def find_class(self, module, name):
-        # override superclass
-        key = (module, name)
-        module, name = pc._class_locations_map.get(key, key)
-        return super().find_class(module, name)
-
-
-CompatUnpickler.dispatch = copy.copy(CompatUnpickler.dispatch)
-CompatUnpickler.dispatch[pickle.REDUCE[0]] = pc.load_reduce
-CompatUnpickler.dispatch[pickle.NEWOBJ[0]] = pc.load_newobj
-
-try:
-    CompatUnpickler.dispatch[pickle.NEWOBJ_EX[0]] = pc.load_newobj_ex
-except (AttributeError, KeyError):
-    pass
-
+    _find_iospec = ModelUnpickler._find_iospec

--- a/modelx/serialize/serializer_4.py
+++ b/modelx/serialize/serializer_4.py
@@ -17,6 +17,7 @@ import json, types, importlib, pathlib
 import ast
 import enum
 import shutil
+import warnings
 from collections import namedtuple
 import tokenize
 import token
@@ -1062,6 +1063,8 @@ class ModelReader:
         self.model = None
         self.pickledata = None
         self.temproot = None
+        self.error_ids = set()          # Keys of lost pickledata entries
+        self.unpickle_errors = []       # Errors caught while unpickling
 
     def read_model(self, **kwargs):
 
@@ -1164,6 +1167,13 @@ class ModelReader:
             self.instructions.extend(instructuions)
 
     def _set_dynamic_inputs(self, idtuple, keyid, valid, static_parent):
+        ids = [k for k in idtuple if isinstance(k, int)]
+        ids.extend((keyid, valid))
+        if any(not self.find_pickledata(i)[0] for i in ids):
+            warnings.warn(
+                "A dynamic input value in '%s' could not be restored "
+                "and was skipped" % static_parent.fullname)
+            return
         idtuple = TupleID.unpickle_args(idtuple, self.pickledata)
         if idtuple[0][0] == ".":    # Backward compatibility (-0.13.0)
             idtuple = rel_to_abs_tuple(idtuple, static_parent._idtuple)
@@ -1189,26 +1199,32 @@ class ModelReader:
             else:
                 self.instructions.append(ist)
 
+    def find_pickledata(self, key):
+        """Return (found, value); found is False when the value was lost."""
+        data = self.pickledata
+        if isinstance(data, dict) and key in data and key not in self.error_ids:
+            return True, data[key]
+        return False, None
+
     def read_pickledata(self):
 
         def custom_load(file):
             unpickler = ModelUnpickler(file, self)
             return unpickler.load()
 
-        def compat_load(file):
-            from .pandas_compat import CompatUnpickler
-            return CompatUnpickler(file, self).load()
-
         file = self.path / "_data/data.pickle"
         if ziputil.exists(file):
-            excs_to_catch = (
-                AttributeError, ImportError, ModuleNotFoundError, TypeError)
             try:
                 self.pickledata = ziputil.read_file_utf8(
                     custom_load, file, "b")
-            except excs_to_catch:
-                self.pickledata = ziputil.read_file_utf8(
-                    compat_load, file, "b")
+            except Exception:
+                from .tolerant_pickle import load_pickle_tolerantly
+                self.pickledata = load_pickle_tolerantly(
+                    self, file, kind="model")
+
+        if self.unpickle_errors:
+            from .tolerant_pickle import finalize_tolerant_read
+            finalize_tolerant_read(self)
 
 
 class BaseNodeParser:
@@ -1547,14 +1563,23 @@ class CellsInputDataMixin(BaseNodeParser):
     def load_pickledata(self):
         if ziputil.exists(self.datapath):
             data = {}
+            skipped = 0
             lines = ziputil.read_file_utf8(lambda f: f.readlines(),
                                       self.datapath,
                                       "t")
             for line in lines:
                 keyid, valid = ast.literal_eval(line)
-                key = self.reader.pickledata[keyid]
-                val = self.reader.pickledata[valid]
+                found_key, key = self.reader.find_pickledata(keyid)
+                found_val, val = self.reader.find_pickledata(valid)
+                if not (found_key and found_val):
+                    skipped += 1
+                    continue
                 data[key] = val
+            if skipped:
+                warnings.warn(
+                    "%d input value(s) of Cells '%s.%s' could not be "
+                    "restored and were skipped"
+                    % (skipped, self.obj.fullname, self.cellsname))
             self.set_values(data)
 
 
@@ -1762,6 +1787,11 @@ class TupleDecoder(ValueDecoder):
     def size(self):
         return len(self.node.elts)
 
+    def _warn_lost_ref(self):
+        warnings.warn(
+            "Reference '%s' in '%s' could not be restored "
+            "and is set to None" % (self.name, self.obj.fullname))
+
     @classmethod
     def condition(cls, node):
         if isinstance(node, ast.Tuple):
@@ -1777,10 +1807,12 @@ class InterfaceDecoder(TupleDecoder):
         return rel_to_abs(self.elm(1), self.obj.fullname)
 
     def restore(self):
-        decoded = TupleID.unpickle_args(
-            TupleID.tuplize(self.atok.get_text(self.node.elts[1])),
-            self.reader.pickledata
-        )
+        keys = TupleID.tuplize(self.atok.get_text(self.node.elts[1]))
+        if any(isinstance(k, int) and not self.reader.find_pickledata(k)[0]
+               for k in keys):
+            self._warn_lost_ref()
+            return None
+        decoded = TupleID.unpickle_args(keys, self.reader.pickledata)
         decoded = rel_to_abs_tuple(decoded, self.obj._idtuple)
         return mxsys.get_object_from_idtuple(decoded)
 
@@ -1792,7 +1824,10 @@ class DataClientDecoder(TupleDecoder):
         return self.elm(1)
 
     def restore(self):
-        spec = self.reader.pickledata[self.decode()]
+        found, spec = self.reader.find_pickledata(self.decode())
+        if not found:
+            self._warn_lost_ref()
+            return None
         if hasattr(spec, "_is_hidden") and spec._is_hidden:
             return spec.value
         else:
@@ -1813,7 +1848,10 @@ class PickleDecoder(TupleDecoder):
         return self.elm(1)
 
     def restore(self):
-        return self.reader.pickledata[self.decode()]
+        found, value = self.reader.find_pickledata(self.decode())
+        if not found:
+            self._warn_lost_ref()
+        return value
 
 
 class LiteralDecoder(ValueDecoder):

--- a/modelx/serialize/serializer_5.py
+++ b/modelx/serialize/serializer_5.py
@@ -17,6 +17,7 @@ import json, types, importlib, pathlib
 import ast
 import enum
 import shutil
+import warnings
 from collections import namedtuple
 import tokenize
 import token
@@ -1056,6 +1057,8 @@ class ModelReader:
         self.pickledata = None
         self.iospecs = None
         self.temproot = None
+        self.error_ids = set()          # Keys of lost pickledata entries
+        self.unpickle_errors = []       # Errors caught while unpickling
 
     def read_model(self, **kwargs):
 
@@ -1159,6 +1162,13 @@ class ModelReader:
             self.instructions.extend(instructuions)
 
     def _set_dynamic_inputs(self, idtuple, keyid, valid, static_parent):
+        ids = [k for k in idtuple if isinstance(k, int)]
+        ids.extend((keyid, valid))
+        if any(not self.find_pickledata(i)[0] for i in ids):
+            warnings.warn(
+                "A dynamic input value in '%s' could not be restored "
+                "and was skipped" % static_parent.fullname)
+            return
         idtuple = TupleID.unpickle_args(idtuple, self.pickledata)
         if idtuple[0][0] == ".":    # Backward compatibility (-0.13.0)
             idtuple = rel_to_abs_tuple(idtuple, static_parent._idtuple)
@@ -1184,36 +1194,47 @@ class ModelReader:
             else:
                 self.instructions.append(ist)
 
+    def find_pickledata(self, key):
+        """Return (found, value); found is False when the value was lost."""
+        data = self.pickledata
+        if isinstance(data, dict) and key in data and key not in self.error_ids:
+            return True, data[key]
+        return False, None
+
     def read_pickledata(self):
 
         def custom_load(file):
             unpickler = ModelUnpickler(file, self)
             return unpickler.load()
 
-        def compat_load(file):
-            from .pandas_compat import CompatUnpickler
-            return CompatUnpickler(file, self).load()
-
         file = self.path / "_data/iospecs.pickle"
         file_old = self.path / "_data/dataspecs.pickle"     # before mx v0.20.0
 
         for f in (file, file_old):
             if ziputil.exists(f):
-                self.iospecs = ziputil.read_file_utf8(
-                    lambda f: IOSpecUnpickler(f, self).load(), f, "b"
-                )
+                try:
+                    self.iospecs = ziputil.read_file_utf8(
+                        lambda f: IOSpecUnpickler(f, self).load(), f, "b"
+                    )
+                except Exception:
+                    from .tolerant_pickle import load_pickle_tolerantly
+                    self.iospecs = load_pickle_tolerantly(
+                        self, f, kind="iospecs")
                 break
 
         file = self.path / "_data/data.pickle"
         if ziputil.exists(file):
-            excs_to_catch = (
-                AttributeError, ImportError, ModuleNotFoundError, TypeError)
             try:
                 self.pickledata = ziputil.read_file_utf8(
                     custom_load, file, "b")
-            except excs_to_catch:
-                self.pickledata = ziputil.read_file_utf8(
-                    compat_load, file, "b")
+            except Exception:
+                from .tolerant_pickle import load_pickle_tolerantly
+                self.pickledata = load_pickle_tolerantly(
+                    self, file, kind="model")
+
+        if self.unpickle_errors:
+            from .tolerant_pickle import finalize_tolerant_read
+            finalize_tolerant_read(self)
 
 
 class BaseNodeParser:
@@ -1552,14 +1573,23 @@ class CellsInputDataMixin(BaseNodeParser):
     def load_pickledata(self):
         if ziputil.exists(self.datapath):
             data = {}
+            skipped = 0
             lines = ziputil.read_file_utf8(lambda f: f.readlines(),
                                       self.datapath,
                                       "t")
             for line in lines:
                 keyid, valid = ast.literal_eval(line)
-                key = self.reader.pickledata[keyid]
-                val = self.reader.pickledata[valid]
+                found_key, key = self.reader.find_pickledata(keyid)
+                found_val, val = self.reader.find_pickledata(valid)
+                if not (found_key and found_val):
+                    skipped += 1
+                    continue
                 data[key] = val
+            if skipped:
+                warnings.warn(
+                    "%d input value(s) of Cells '%s.%s' could not be "
+                    "restored and were skipped"
+                    % (skipped, self.obj.fullname, self.cellsname))
             self.set_values(data)
 
 
@@ -1767,6 +1797,11 @@ class TupleDecoder(ValueDecoder):
     def size(self):
         return len(self.node.elts)
 
+    def _warn_lost_ref(self):
+        warnings.warn(
+            "Reference '%s' in '%s' could not be restored "
+            "and is set to None" % (self.name, self.obj.fullname))
+
     @classmethod
     def condition(cls, node):
         if isinstance(node, ast.Tuple):
@@ -1785,10 +1820,12 @@ class InterfaceDecoder(TupleDecoder):
         return rel_to_abs(self.elm(1), self.obj.fullname)
 
     def restore(self):
-        decoded = TupleID.unpickle_args(
-            TupleID.tuplize(self.atok.get_text(self.node.elts[1])),
-            self.reader.pickledata
-        )
+        keys = TupleID.tuplize(self.atok.get_text(self.node.elts[1]))
+        if any(isinstance(k, int) and not self.reader.find_pickledata(k)[0]
+               for k in keys):
+            self._warn_lost_ref()
+            return None
+        decoded = TupleID.unpickle_args(keys, self.reader.pickledata)
         decoded = rel_to_abs_tuple(decoded, self.obj._idtuple)
         return mxsys.get_object_from_idtuple(decoded)
 
@@ -1801,7 +1838,10 @@ class IOSpecDecoder(TupleDecoder):
         return self.elm(1)
 
     def restore(self):
-        return self.reader.pickledata[self.decode()]
+        found, value = self.reader.find_pickledata(self.decode())
+        if not found:
+            self._warn_lost_ref()
+        return value
 
 
 class ModuleDecoder(TupleDecoder):
@@ -1818,7 +1858,10 @@ class PickleDecoder(TupleDecoder):
         return self.elm(1)
 
     def restore(self):
-        return self.reader.pickledata[self.decode()]
+        found, value = self.reader.find_pickledata(self.decode())
+        if not found:
+            self._warn_lost_ref()
+        return value
 
 
 class LiteralDecoder(ValueDecoder):

--- a/modelx/serialize/serializer_6.py
+++ b/modelx/serialize/serializer_6.py
@@ -17,6 +17,7 @@ import json, types, importlib, pathlib
 import ast
 import enum
 import shutil
+import warnings
 from types import MethodType, FunctionType
 import tokenize
 import token
@@ -868,6 +869,8 @@ class ModelReader:
         self.pickledata = None
         self.iospecs = None
         self.temproot = None
+        self.error_ids = set()          # Keys of lost pickledata entries
+        self.unpickle_errors = []       # Errors caught while unpickling
 
     def read_model(self, **kwargs):
 
@@ -968,6 +971,13 @@ class ModelReader:
             self.instructions.extend(instructuions)
 
     def _set_dynamic_inputs(self, idtuple, keyid, valid, static_parent):
+        ids = [k for k in idtuple if isinstance(k, int)]
+        ids.extend((keyid, valid))
+        if any(not self.find_pickledata(i)[0] for i in ids):
+            warnings.warn(
+                "A dynamic input value in '%s' could not be restored "
+                "and was skipped" % static_parent.fullname)
+            return
         idtuple = TupleID.unpickle_args(idtuple, self.pickledata)
         if idtuple[0][0] == ".":    # Backward compatibility (-0.13.0)
             idtuple = rel_to_abs_tuple(idtuple, static_parent._idtuple)
@@ -984,36 +994,47 @@ class ModelReader:
             )
             parser.set_instruction()
 
+    def find_pickledata(self, key):
+        """Return (found, value); found is False when the value was lost."""
+        data = self.pickledata
+        if isinstance(data, dict) and key in data and key not in self.error_ids:
+            return True, data[key]
+        return False, None
+
     def read_pickledata(self):
 
         def custom_load(file):
             unpickler = ModelUnpickler(file, self)
             return unpickler.load()
 
-        def compat_load(file):
-            from .pandas_compat import CompatUnpickler
-            return CompatUnpickler(file, self).load()
-
         file = self.path / "_data/iospecs.pickle"
         file_old = self.path / "_data/dataspecs.pickle"     # before mx v0.20.0
 
         for f in (file, file_old):
             if ziputil.exists(f):
-                self.iospecs = ziputil.read_file_utf8(
-                    lambda f: IOSpecUnpickler(f, self).load(), f, "b"
-                )
+                try:
+                    self.iospecs = ziputil.read_file_utf8(
+                        lambda f: IOSpecUnpickler(f, self).load(), f, "b"
+                    )
+                except Exception:
+                    from .tolerant_pickle import load_pickle_tolerantly
+                    self.iospecs = load_pickle_tolerantly(
+                        self, f, kind="iospecs")
                 break
 
         file = self.path / "_data/data.pickle"
         if ziputil.exists(file):
-            excs_to_catch = (
-                AttributeError, ImportError, ModuleNotFoundError, TypeError)
             try:
                 self.pickledata = ziputil.read_file_utf8(
                     custom_load, file, "b")
-            except excs_to_catch:
-                self.pickledata = ziputil.read_file_utf8(
-                    compat_load, file, "b")
+            except Exception:
+                from .tolerant_pickle import load_pickle_tolerantly
+                self.pickledata = load_pickle_tolerantly(
+                    self, file, kind="model")
+
+        if self.unpickle_errors:
+            from .tolerant_pickle import finalize_tolerant_read
+            finalize_tolerant_read(self)
 
 
 class BaseNodeParser:
@@ -1322,14 +1343,23 @@ class CellsInputDataMixin(BaseNodeParser):
     def load_pickledata(self):
         if ziputil.exists(self.datapath):
             data = {}
+            skipped = 0
             lines = ziputil.read_file_utf8(lambda f: f.readlines(),
                                       self.datapath,
                                       "t")
             for line in lines:
                 keyid, valid = ast.literal_eval(line)
-                key = self.reader.pickledata[keyid]
-                val = self.reader.pickledata[valid]
+                found_key, key = self.reader.find_pickledata(keyid)
+                found_val, val = self.reader.find_pickledata(valid)
+                if not (found_key and found_val):
+                    skipped += 1
+                    continue
                 data[key] = val
+            if skipped:
+                warnings.warn(
+                    "%d input value(s) of Cells '%s.%s' could not be "
+                    "restored and were skipped"
+                    % (skipped, self.obj.fullname, self.cellsname))
             self.set_values(data)
 
 
@@ -1585,6 +1615,11 @@ class TupleDecoder(ValueDecoder):
     def size(self):
         return len(self.value)
 
+    def _warn_lost_ref(self):
+        warnings.warn(
+            "Reference '%s' in '%s' could not be restored "
+            "and is set to None" % (self.name, self.obj.fullname))
+
     @classmethod
     def condition(cls, stmt):
         if stmt.section == "REFDEFS":
@@ -1604,10 +1639,12 @@ class InterfaceDecoder(TupleDecoder):
         return rel_to_abs(self.value[1], self.obj.fullname)
 
     def restore(self):
-        decoded = TupleID.unpickle_args(
-            self.value[1],
-            self.reader.pickledata
-        )
+        keys = self.value[1]
+        if any(isinstance(k, int) and not self.reader.find_pickledata(k)[0]
+               for k in keys):
+            self._warn_lost_ref()
+            return None
+        decoded = TupleID.unpickle_args(keys, self.reader.pickledata)
         decoded = rel_to_abs_tuple(decoded, self.obj._idtuple)
         return mxsys.get_object_from_idtuple(decoded)
 
@@ -1620,7 +1657,10 @@ class IOSpecDecoder(TupleDecoder):
         return self.value[1]
 
     def restore(self):
-        return self.reader.pickledata[self.decode()]
+        found, value = self.reader.find_pickledata(self.decode())
+        if not found:
+            self._warn_lost_ref()
+        return value
 
 
 class ModuleDecoder(TupleDecoder):
@@ -1637,7 +1677,10 @@ class PickleDecoder(TupleDecoder):
         return self.value[1]
 
     def restore(self):
-        return self.reader.pickledata[self.decode()]
+        found, value = self.reader.find_pickledata(self.decode())
+        if not found:
+            self._warn_lost_ref()
+        return value
 
 
 class LiteralDecoder(ValueDecoder):

--- a/modelx/serialize/tolerant_pickle.py
+++ b/modelx/serialize/tolerant_pickle.py
@@ -1,0 +1,366 @@
+# Copyright (c) 2017-2026 Fumito Hamamura <fumito.ham@gmail.com>
+
+# This library is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation version 3.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Error-tolerant unpicklers for reading pickle files in saved models.
+
+When objects in "_data/data.pickle" or "_data/iospecs.pickle" cannot be
+unpickled in the current environment (e.g. because the packages they were
+pickled with have changed), the unpicklers here substitute placeholders for
+the broken objects instead of aborting, so that the rest of the model can
+still be loaded. Objects assembled from broken parts are contaminated
+transitively, opcode by opcode, so that e.g. a DataFrame whose internal
+blocks failed to load is discarded as a whole even when its __setstate__
+swallows the placeholders without raising. After loading,
+``sweep_pickledata`` replaces every entry whose value is or contains a
+broken object with None and reports the entry's key, so the readers can
+warn the user and skip or nullify only the affected values.
+
+The pure-Python ``pickle._Unpickler`` executes most opcodes through the
+class-level ``dispatch`` dict, so the error-trapping handlers must be wired
+into a copy of that dict; only ``find_class`` and ``persistent_load`` can be
+overridden as regular methods.
+"""
+
+import copy
+import pickle
+import warnings
+
+from . import ziputil
+from .custom_pickle import ModelUnpickler, IOSpecUnpickler
+
+try:
+    from .pandas_compat import CompatBase as _CompatBase
+except ImportError:     # pandas not installed
+    _CompatBase = pickle._Unpickler
+
+
+def _noop(*args, **kwargs):
+    return None
+
+
+class ErrorPlaceholder:
+    """Stand-in pushed on the unpickling stack for objects that failed to load.
+
+    Tolerates the operations pickle may perform on it afterwards, so that
+    the rest of the stream keeps parsing. ``__call__``, ``__setitem__`` and
+    ``__new__`` must be real methods because pickle reaches them through
+    implicit type-level lookup (``__new__`` explicitly so, rather than via
+    object.__new__'s leniency when only __init__ is overridden); the
+    remaining operations (append, extend, add, update, __setstate__, ...)
+    are explicit attribute accesses covered by ``__getattr__``.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        return object.__new__(cls)
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def __setitem__(self, key, value):
+        pass
+
+    def __getattr__(self, name):
+        return _noop
+
+
+def _substitute_top(unpickler, exc):
+    if exc is not None:
+        unpickler._record(exc)
+    unpickler.stack[-1] = ErrorPlaceholder()
+
+
+def _append_placeholder(unpickler, exc):
+    if exc is not None:
+        unpickler._record(exc)
+    unpickler.append(ErrorPlaceholder())
+
+
+def _contaminate_top(unpickler, exc):
+    # The object is memoized before BUILD and container fills run, so it
+    # must stay on the stack; record its identity instead of replacing it.
+    if exc is not None:
+        unpickler._record(exc)
+    obj = unpickler.stack[-1]
+    unpickler.contaminated[id(obj)] = obj   # value kept alive so id stays valid
+
+
+class _TolerantUnpickler(_CompatBase):
+    """Unpickler that substitutes placeholders for objects that fail to load."""
+
+    def __init__(self, file, reader):
+        super().__init__(file)
+        self.reader = reader
+        self.manager = reader.system.iomanager
+        self.model = reader.model
+        if reader.version >= 5:
+            self.iospecs = reader.iospecs
+        self.errors = []
+        self.contaminated = {}      # id -> object built from broken parts
+
+    def _record(self, exc):
+        self.errors.append(exc)
+
+    def _is_bad(self, obj):
+        return (obj is ErrorPlaceholder
+                or isinstance(obj, ErrorPlaceholder)
+                or id(obj) in self.contaminated)
+
+    def find_class(self, module, name):
+        try:
+            return super().find_class(module, name)
+        except Exception as exc:
+            self._record(exc)
+            return ErrorPlaceholder
+
+    def persistent_load(self, pid):
+        try:
+            return self._persistent_load(pid)
+        except Exception as exc:
+            self._record(exc)
+            return ErrorPlaceholder()
+
+
+# Contamination is propagated per opcode with O(1) membership checks on the
+# operands: every aggregate an opcode builds or fills is checked against the
+# elements it consumes, so containment never requires re-scanning whole
+# structures during the load (a deep scan happens once, in sweep_pickledata).
+
+def _peek_top(u):
+    return u._is_bad(u.stack[-1])
+
+
+def _peek_top2(u):
+    return u._is_bad(u.stack[-1]) or u._is_bad(u.stack[-2])
+
+
+def _peek_top3(u):
+    return any(map(u._is_bad, u.stack[-3:]))
+
+
+def _peek_mark(u):
+    # At a mark-based opcode, self.stack is exactly the mark segment
+    return any(map(u._is_bad, u.stack))
+
+
+def _make_tolerant_dispatch(cls):
+    """Copy ``cls.dispatch`` and wrap the handlers that can run user code
+    or aggregate previously loaded objects.
+
+    Each wrapper substitutes a placeholder (or contaminates the built
+    object) when the wrapped handler raises, and also when the handler
+    succeeds but its operands were broken (``peek`` inspects the operands
+    on the stack before the handler pops them; ``taint`` marks the result
+    afterwards).
+    """
+
+    cls.dispatch = copy.copy(cls.dispatch)
+
+    def wrap(code, fixup=None, peek=None, taint=None):
+        inner = cls.dispatch.get(code[0])
+        if inner is None:
+            return
+
+        def handler(self, _inner=inner, _fixup=fixup, _peek=peek,
+                    _taint=taint):
+            if _peek is not None and self.errors:
+                tainted = _peek(self)
+            else:
+                tainted = False
+            if _fixup is None:
+                _inner(self)
+            else:
+                try:
+                    _inner(self)
+                except Exception as exc:
+                    _fixup(self, exc)
+                    return
+            if tainted:
+                _taint(self, None)
+
+        cls.dispatch[code[0]] = handler
+
+    # Object construction: on failure or broken operands the result is a
+    # placeholder (the failed/tainted result was never inserted anywhere yet)
+    wrap(pickle.REDUCE, _substitute_top, _peek_top, _substitute_top)
+    wrap(pickle.NEWOBJ, _append_placeholder, _peek_top, _substitute_top)
+    wrap(pickle.NEWOBJ_EX, _append_placeholder, _peek_top2, _substitute_top)
+    wrap(pickle.INST, _append_placeholder, _peek_mark, _substitute_top)
+    wrap(pickle.OBJ, _append_placeholder, _peek_mark, _substitute_top)
+    for code in (pickle.EXT1, pickle.EXT2, pickle.EXT4):
+        wrap(code, _append_placeholder)
+
+    # State/content mutation of an already-memoized object: keep the object
+    # and contaminate it
+    wrap(pickle.BUILD, _contaminate_top, _peek_top, _contaminate_top)
+    wrap(pickle.SETITEM, _contaminate_top, _peek_top2, _contaminate_top)
+    wrap(pickle.APPEND, _contaminate_top, _peek_top, _contaminate_top)
+    for code in (pickle.SETITEMS, pickle.APPENDS, pickle.ADDITEMS):
+        wrap(code, _contaminate_top, _peek_mark, _contaminate_top)
+
+    # Builtin containers built from loaded elements: can only fail on
+    # element hashing (DICT/FROZENSET); all propagate contamination
+    wrap(pickle.DICT, _append_placeholder, _peek_mark, _contaminate_top)
+    wrap(pickle.FROZENSET, _append_placeholder, _peek_mark, _contaminate_top)
+    wrap(pickle.TUPLE, None, _peek_mark, _contaminate_top)
+    wrap(pickle.LIST, None, _peek_mark, _contaminate_top)
+    wrap(pickle.TUPLE1, None, _peek_top, _contaminate_top)
+    wrap(pickle.TUPLE2, None, _peek_top2, _contaminate_top)
+    wrap(pickle.TUPLE3, None, _peek_top3, _contaminate_top)
+
+
+class TolerantModelUnpickler(_TolerantUnpickler):
+    """Tolerant substitute for ModelUnpickler (reads _data/data.pickle)"""
+
+    _persistent_load = ModelUnpickler.persistent_load
+    _find_iospec = ModelUnpickler._find_iospec
+
+
+class TolerantIOSpecUnpickler(_TolerantUnpickler):
+    """Tolerant substitute for IOSpecUnpickler (reads _data/iospecs.pickle)"""
+
+    _persistent_load = IOSpecUnpickler.persistent_load
+
+
+_make_tolerant_dispatch(TolerantModelUnpickler)
+_make_tolerant_dispatch(TolerantIOSpecUnpickler)
+
+
+def _contains_error(value, contaminated):
+
+    if (value is ErrorPlaceholder or isinstance(value, ErrorPlaceholder)
+            or id(value) in contaminated):
+        return True
+    if not isinstance(value, (list, tuple, dict, set, frozenset)):
+        return False
+
+    # Deep scan of builtin containers: contamination tracking covers
+    # aggregates the unpickler built, but cyclic or reordered fills can
+    # bury a broken object without contaminating every ancestor
+    seen = set()
+    stack = [value]
+    while stack:
+        obj = stack.pop()
+        if (obj is ErrorPlaceholder or isinstance(obj, ErrorPlaceholder)
+                or id(obj) in contaminated):
+            return True
+        if isinstance(obj, (list, tuple, set, frozenset)):
+            if id(obj) not in seen:
+                seen.add(id(obj))
+                stack.extend(obj)
+        elif isinstance(obj, dict):
+            if id(obj) not in seen:
+                seen.add(id(obj))
+                stack.extend(obj.keys())
+                stack.extend(obj.values())
+    return False
+
+
+def sweep_pickledata(data, contaminated=()):
+    """Replace dict entries holding unrestorable objects with None.
+
+    Returns the set of keys whose values were replaced.
+    """
+    error_keys = set()
+    for key, value in data.items():
+        if _contains_error(value, contaminated):
+            data[key] = None
+            error_keys.add(key)
+    return error_keys
+
+
+def _reset_model_ios(reader):
+    # Discard IOs (and specs attached to them) registered by an aborted
+    # unpickling attempt, so a retry does not duplicate the specs.
+    # IOs keyed by absolute path may be shared with other models and are
+    # left to delete_orphan_ios, which only removes spec-less ones.
+    manager = reader.system.iomanager
+    for io_ in list(manager.get_ios(reader.model).values()):
+        for spec in list(io_.specs.values()):
+            manager.del_spec(spec)
+        if not io_.specs:
+            manager._del_io(io_)
+
+
+def load_pickle_tolerantly(reader, path, kind):
+    """Load a pickle file substituting None for unrestorable values.
+
+    ``kind`` is "model" for _data/data.pickle or "iospecs" for
+    _data/iospecs.pickle. Records caught errors and the affected entries'
+    keys on the reader. Returns an empty dict if the file cannot be parsed
+    at all (e.g. a truncated stream).
+    """
+    if kind == "iospecs" or reader.version < 5:
+        # The aborted strict attempt may have registered IOs and attached
+        # specs (from iospecs.pickle, or from data.pickle in v4 models
+        # where specs are pickled by value); discard them before retrying
+        _reset_model_ios(reader)
+
+    cls = TolerantModelUnpickler if kind == "model" else TolerantIOSpecUnpickler
+    unpickler = None
+
+    def loadfunc(file):
+        nonlocal unpickler
+        unpickler = cls(file, reader)
+        return unpickler.load()
+
+    try:
+        data = ziputil.read_file_utf8(loadfunc, path, "b")
+        if not isinstance(data, dict):
+            raise TypeError("unexpected data in '%s': %r" % (path, data))
+    except Exception as exc:
+        reader.unpickle_errors.append(exc)
+        warnings.warn(
+            "'%s' could not be read (%r); "
+            "all values stored in it are lost" % (path, exc))
+        return {}
+
+    reader.unpickle_errors.extend(unpickler.errors)
+    reader.error_ids.update(
+        sweep_pickledata(data, unpickler.contaminated))
+    return data
+
+
+def finalize_tolerant_read(reader):
+    """Post-process a read that recorded unpickling errors: warn a summary
+    of all recorded errors and remove IOs left with no specs by failed
+    spec loads."""
+    excs = []
+    seen = set()
+    for exc in reader.unpickle_errors:
+        r = repr(exc)
+        if r not in seen:
+            seen.add(r)
+            excs.append(r)
+    shown = "; ".join(excs[:5])
+    if len(excs) > 5:
+        shown += "; and %d more" % (len(excs) - 5)
+    warnings.warn(
+        "%d error(s) occurred while restoring pickled values in model '%s'; "
+        "the affected values are replaced with None or skipped: %s"
+        % (len(reader.unpickle_errors), reader.model.name, shown))
+
+    delete_orphan_ios(reader)
+
+
+def delete_orphan_ios(reader):
+    """Remove IOs left with no specs by failed spec loads."""
+    manager = reader.system.iomanager
+    ios = list(manager.get_ios(reader.model).values())
+    ios.extend(manager.get_ios(None).values())     # absolute-path IOs
+    for io_ in ios:
+        if not io_.specs:
+            manager._del_io(io_)

--- a/modelx/tests/serialize/conftest.py
+++ b/modelx/tests/serialize/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+import modelx as mx
+
+
+@pytest.fixture
+def close_new_models():
+    """Close every model created during the test, including partially
+    built ones left behind if a reader raises mid-load."""
+    before = set(mx.get_models())
+    yield
+    for name, model in list(mx.get_models().items()):
+        if name not in before:
+            model.close()

--- a/modelx/tests/serialize/test_pandas_compat.py
+++ b/modelx/tests/serialize/test_pandas_compat.py
@@ -11,8 +11,22 @@ import pandas as pd
 mort_tables = pd.read_pickle(PD_COMPAT_MORTTBL)
 
 @pytest.mark.skipif(Version(pd.__version__) >= Version("3.0.0"),
-                    reason="Pandas compatibility test is for Pandas < 2.0.0")
+                    reason="Pandas compatibility fix is for Pandas < 3.0.0")
 @pytest.mark.parametrize("model", [PD_COMPAT_DIR, PD_COMPAT_ZIP])
 def test_pandas_compat(model):
     m = mx.read_model(model)
     assert m.Input.MortalityTables.equals(mort_tables)
+    m.close()
+
+
+@pytest.mark.skipif(Version(pd.__version__) < Version("3.0.0"),
+                    reason="Tolerant-load fallback applies from Pandas 3.0.0")
+@pytest.mark.parametrize("model", [PD_COMPAT_DIR, PD_COMPAT_ZIP])
+def test_pandas_compat_tolerant(model):
+    # Pandas 3 dropped the compat hooks needed to rebuild these old
+    # DataFrames, so the model loads with the tables replaced by None
+    # instead of failing to load altogether.
+    with pytest.warns(UserWarning, match="could not be restored"):
+        m = mx.read_model(model)
+    assert m.Input.MortalityTables is None
+    m.close()

--- a/modelx/tests/serialize/test_serializer_compat.py
+++ b/modelx/tests/serialize/test_serializer_compat.py
@@ -24,17 +24,6 @@ DATADIR = pathlib.Path(fixturemodel.__file__).parent
 VERSIONS = [4, 5, 6, 7]
 
 
-@pytest.fixture
-def close_new_models():
-    """Close every model created during the test, including partially
-    built ones left behind if a reader raises mid-load."""
-    before = set(mx.get_models())
-    yield
-    for name, model in list(mx.get_models().items()):
-        if name not in before:
-            model.close()
-
-
 @pytest.mark.parametrize("version", VERSIONS)
 def test_load_fixture_model(version, close_new_models):
     """A model saved by serializer_<version> loads and behaves."""

--- a/modelx/tests/serialize/test_tolerant_unpickle.py
+++ b/modelx/tests/serialize/test_tolerant_unpickle.py
@@ -1,0 +1,274 @@
+"""Tolerant unpickling: models load even when pickled values cannot be
+restored in the current environment.
+
+Serializers 4-7 substitute None for references whose pickled values fail
+to unpickle, skip unrestorable cells inputs and dynamic inputs, and warn
+about every substitution, instead of aborting the whole load
+(see modelx/serialize/tolerant_pickle.py).
+"""
+
+import pathlib
+import pickle
+import shutil
+import sys
+import textwrap
+import zipfile
+
+import pytest
+
+import modelx as mx
+from modelx.core.system import mxsys
+from modelx.tests.testdata.serializer_compat import fixturemodel
+
+DATADIR = pathlib.Path(fixturemodel.__file__).parent
+
+VERSIONS = [4, 5, 6, 7]
+
+
+class Unrestorable:
+    """Pickles cleanly but always fails to unpickle."""
+
+    def __getstate__(self):
+        return {}
+
+    def __setstate__(self, state):
+        raise RuntimeError("unrestorable object")
+
+
+@pytest.fixture(params=["write_model", "zip_model"])
+def write_meth(request):
+    return getattr(mx, request.param)
+
+
+def test_lost_ref_and_input(tmp_path, write_meth, close_new_models):
+    """Poisoned refs become None and poisoned cells inputs are skipped;
+    healthy values survive, and the loaded model can be saved again."""
+    m = mx.new_model()
+    s = m.new_space("Space1")
+    s.new_cells(name="foo", formula=lambda x: x * 2)
+    s.foo[0] = 100
+    s.foo[1] = Unrestorable()
+    s.bad = Unrestorable()
+    s.shared = s.bad
+    s.good = [1, 2, 3]
+    s.lit = 42
+
+    path = tmp_path / "model"
+    write_meth(m, str(path))
+    m.close()
+
+    with pytest.warns(UserWarning, match="could not be restored"):
+        m2 = mx.read_model(str(path))
+
+    assert m2.Space1.bad is None
+    assert m2.Space1.shared is None
+    assert m2.Space1.good == [1, 2, 3]
+    assert m2.Space1.lit == 42
+    assert m2.Space1.foo[0] == 100
+    assert m2.Space1.foo[1] == 2    # skipped input recomputed by formula
+
+    # A model loaded with holes can be saved and loaded again
+    path2 = tmp_path / "model2"
+    write_meth(m2, str(path2))
+    m3 = mx.read_model(str(path2))
+    assert m3.Space1.bad is None
+    assert m3.Space1.foo[0] == 100
+
+
+def test_lost_input_key(tmp_path, write_meth, close_new_models):
+    """A cells input whose key cannot be restored is skipped."""
+    m = mx.new_model()
+    s = m.new_space("Space1")
+    s.new_cells(name="foo", formula=lambda x: 0)
+    s.foo[Unrestorable()] = 3
+    s.foo["ok"] = 4
+
+    path = tmp_path / "model"
+    write_meth(m, str(path))
+    m.close()
+
+    with pytest.warns(UserWarning, match="input value.*could not be restored"):
+        m2 = mx.read_model(str(path))
+
+    assert m2.Space1.foo["ok"] == 4
+    assert len(m2.Space1.foo._impl.input_keys) == 1
+
+
+def test_lost_dynamic_input(tmp_path, write_meth, close_new_models):
+    """A dynamic (itemspace) input whose value cannot be restored is
+    skipped."""
+    m = mx.new_model()
+    s = m.new_space("Space1", formula=lambda i: None)
+    s.new_cells(name="foo", formula=lambda x: x)
+    s[1].foo[0] = Unrestorable()
+    s[2].foo[0] = "kept"
+
+    path = tmp_path / "model"
+    write_meth(m, str(path))
+    m.close()
+
+    with pytest.warns(UserWarning, match="dynamic input.*could not be restored"):
+        m2 = mx.read_model(str(path))
+
+    assert m2.Space1[2].foo[0] == "kept"
+    assert m2.Space1[1].foo[0] == 0     # recomputed by formula
+
+
+def test_unimportable_module(tmp_path, write_meth, close_new_models):
+    """A ref whose class's module no longer exists becomes None."""
+    moddir = tmp_path / "mods"
+    moddir.mkdir()
+    (moddir / "ghost_mod_tolerant.py").write_text(textwrap.dedent("""\
+        class Ghost:
+            pass
+    """))
+    sys.path.insert(0, str(moddir))
+    try:
+        import ghost_mod_tolerant
+        m = mx.new_model()
+        s = m.new_space("Space1")
+        s.gref = ghost_mod_tolerant.Ghost()
+        s.lit = 1
+        path = tmp_path / "model"
+        write_meth(m, str(path))
+        m.close()
+    finally:
+        sys.path.remove(str(moddir))
+        sys.modules.pop("ghost_mod_tolerant", None)
+
+    with pytest.warns(UserWarning, match="could not be restored"):
+        m2 = mx.read_model(str(path))
+
+    assert m2.Space1.gref is None
+    assert m2.Space1.lit == 1
+
+
+def test_corrupt_data_pickle(tmp_path, close_new_models):
+    """A truncated data.pickle loses all pickled values but the model
+    still loads."""
+    m = mx.new_model()
+    s = m.new_space("Space1")
+    s.ref1 = [1, 2, 3]
+    s.lit = 7
+    path = tmp_path / "model"
+    mx.write_model(m, str(path))
+    m.close()
+
+    dfile = path / "_data" / "data.pickle"
+    dfile.write_bytes(dfile.read_bytes()[:5])
+
+    with pytest.warns(UserWarning, match="could not be read"):
+        m2 = mx.read_model(str(path))
+
+    assert m2.Space1.ref1 is None
+    assert m2.Space1.lit == 7
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_poisoned_fixture_model(version, tmp_path, close_new_models):
+    """Serializer-4 to -7 models with an unrestorable pickled value load
+    with a warning and keep everything else."""
+    src = DATADIR / ("model_v%s" % version)
+    dst = tmp_path / src.name
+    shutil.copytree(str(src), str(dst))
+
+    # The fixtures' data.pickle contains no persistent ids, so it can be
+    # rewritten with the plain pickle module.
+    pfile = dst / "_data" / "data.pickle"
+    with pfile.open("rb") as f:
+        data = pickle.load(f)
+    data[999999001] = Unrestorable()
+    with pfile.open("wb") as f:
+        pickle.dump(data, f)
+
+    with pytest.warns(UserWarning, match="unrestorable object"):
+        m = mx.read_model(str(dst))
+    fixturemodel.check_fixture_model(m)
+
+
+def _make_pandas_model(name):
+    pd = pytest.importorskip("pandas")
+    df = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
+    m = mx.new_model(name)
+    s = m.new_space("Space1")
+    s.new_pandas(name="pdref", path="files/data.xlsx",
+                 data=df, file_type="excel")
+    s.other = 5
+    return m
+
+
+def _assert_pandas_ref_lost(m):
+    assert m.Space1.pdref is None
+    assert m.Space1.other == 5
+    assert m.iospecs == []
+    assert not [io_ for (group, path), io_ in mxsys.iomanager.ios.items()
+                if group is m or group is None]
+
+
+def test_iospec_data_file_missing_dir(tmp_path, close_new_models):
+    """Deleting the file behind an IO spec: the ref becomes None and no
+    orphan IO is left behind."""
+    pytest.importorskip("openpyxl")
+    m = _make_pandas_model("IOModelDir")
+    path = tmp_path / "model"
+    mx.write_model(m, str(path))
+    m.close()
+
+    (path / "files" / "data.xlsx").unlink()
+
+    with pytest.warns(UserWarning, match="could not be restored"):
+        m2 = mx.read_model(str(path))
+    _assert_pandas_ref_lost(m2)
+
+
+def test_iospec_data_file_missing_zip(tmp_path, close_new_models):
+    """Same as above for a zipped model (archive rebuilt without the
+    member)."""
+    pytest.importorskip("openpyxl")
+    m = _make_pandas_model("IOModelZip")
+    path = tmp_path / "model.zip"
+    mx.zip_model(m, str(path))
+    m.close()
+
+    trimmed = tmp_path / "trimmed.zip"
+    with zipfile.ZipFile(str(path)) as zin, \
+            zipfile.ZipFile(str(trimmed), "w") as zout:
+        for item in zin.infolist():
+            if not item.filename.endswith("data.xlsx"):
+                zout.writestr(item, zin.read(item.filename))
+
+    with pytest.warns(UserWarning, match="could not be restored"):
+        m2 = mx.read_model(str(trimmed))
+    _assert_pandas_ref_lost(m2)
+
+
+def test_iospecs_pickle_corrupt(tmp_path, close_new_models):
+    """A truncated iospecs.pickle loses the specs but the model loads."""
+    pytest.importorskip("openpyxl")
+    m = _make_pandas_model("IOModelCorrupt")
+    path = tmp_path / "model"
+    mx.write_model(m, str(path))
+    m.close()
+
+    iofile = path / "_data" / "iospecs.pickle"
+    iofile.write_bytes(iofile.read_bytes()[:10])
+
+    with pytest.warns(UserWarning, match="could not be read"):
+        m2 = mx.read_model(str(path))
+    _assert_pandas_ref_lost(m2)
+
+
+def test_iospecs_pickle_missing(tmp_path, close_new_models):
+    """With iospecs.pickle deleted, DataValue references in data.pickle
+    resolve to None."""
+    pytest.importorskip("openpyxl")
+    m = _make_pandas_model("IOModelMissing")
+    path = tmp_path / "model"
+    mx.write_model(m, str(path))
+    m.close()
+
+    (path / "_data" / "iospecs.pickle").unlink()
+
+    with pytest.warns(UserWarning, match="could not be restored"):
+        m2 = mx.read_model(str(path))
+    _assert_pandas_ref_lost(m2)


### PR DESCRIPTION
## What

Serializers 4-7 now load models even when values in `_data/data.pickle` or (v5+) `_data/iospecs.pickle` cannot be unpickled in the current environment, instead of aborting the whole `read_model`:

- **References** whose pickled values fail to restore are set to **None**, with a warning naming the space and ref.
- **Cells inputs and dynamic (itemspace) inputs** that fail are **skipped** with a warning (storing None would raise `NoneReturnedError` when `allow_none` is False, and a broken key would create a bogus node); the value is recomputed from the formula on demand.
- **Broken IO specs** (missing/corrupt Excel/CSV/module files, lost `iospecs.pickle`) cost only the affected refs; IOs orphaned by failed spec loads are removed so a later `write_model` stays consistent.
- **Corrupt/truncated pickle files** lose their values but the model still loads, and a summary warning lists the distinct underlying errors.
- Models loaded with holes re-save cleanly (None refs re-encode as literals).

## How

The fast C unpicklers run unchanged on the happy path. On any failure the file is re-read with a pure-Python tolerant unpickler (new `modelx/serialize/tolerant_pickle.py`): opcode handlers are wrapped via a copy of `pickle._Unpickler.dispatch` to substitute an `ErrorPlaceholder` on failure, and *contamination* is propagated per opcode with O(1) operand checks so that objects assembled from broken parts are also discarded — e.g. a DataFrame whose internal blocks failed to load but whose `__setstate__` swallowed the placeholders without raising. A post-load sweep replaces affected dict entries with None and records their ids; the per-version readers (`serializer_4/5/6.py`; v7 inherits from v6) consult those ids to warn and skip/nullify only the affected values.

`ModelUnpickler.persistent_load`'s `DataValue`/`BaseIOSpec` branches now raise a clean `KeyError` via `_find_iospec` when the spec is unavailable, so the strict pass falls back to the tolerant pass rather than leaking sentinels.

## pandas note

The existing pandas-compat fallback was broken on pandas >= 3.0: `pandas_compat.py` accessed the removed `pc.load_reduce` at import time. The module now feature-detects the pandas compat unpickler base (exposed as `CompatBase`, also used by the tolerant unpickler), and the old-pandas fastlife fixture — genuinely unrecoverable on pandas 3 (`FrozenNDArray`) — now loads with `MortalityTables` as None instead of failing outright. `test_pandas_compat.py` covers both pandas generations.

## Reviewer notes

- `read_pickledata` and the consumer guards are intentionally replicated across `serializer_4/5/6.py`, matching the frozen-per-version convention; shared machinery lives in `tolerant_pickle.py`.
- The v4-v7 backward-compat poisoned-fixture tests rewrite copies of `testdata/serializer_compat/model_vN` at test time (their `data.pickle` contains no persistent ids), so no old-version worktrees are needed.
- Verified: full suite (1103 passed, 6 skipped) on py313 with pandas 3.0.0; new `test_tolerant_unpickle.py` adds 17 cases (dir+zip round-trips, poisoned v4-v7 fixtures, IO-spec failures, corruption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)