### PR TITLE
FIX: Roll back IOManager registrations when model reads fail

### DIFF
--- a/modelx/io/baseio.py
+++ b/modelx/io/baseio.py
@@ -150,6 +150,48 @@ class IOManager:
     def __init__(self):
         self.ios = BiDict({})
         self.serializing = None     # Set from external
+        self._journal = None        # Records additions during a model read
+
+    # ----------------------------------------------------------------------
+    # Journaling for rollback on failed model reads
+    #
+    # While a model is being read, IOs and specs enter ``self.ios`` before
+    # the refs that would make them reachable from the model's
+    # ValueRegistry, so closing the model cannot undo them. The reader
+    # journals every addition and rolls the journal back when the read
+    # fails, or up to a mark when a strict unpickling attempt is retried.
+
+    def begin_journal(self):
+        self._journal = []
+
+    def end_journal(self):
+        self._journal = None
+
+    def journal_mark(self):
+        return len(self._journal) if self._journal is not None else 0
+
+    def rollback_journal(self, mark=0, io_group=None):
+        """Undo io/spec registrations journaled after ``mark``.
+
+        Entries whose io is keyed under a group other than ``io_group``
+        or None are kept: they belong to another model mutated as a
+        side effect (e.g. by module code executed while unpickling).
+        Entries already removed by other cleanups, such as ``del_spec``
+        via the model's ValueRegistry, are skipped.
+        """
+        if self._journal is None:
+            return
+        while len(self._journal) > mark:
+            kind, obj = self._journal.pop()
+            a_io = obj if kind == "io" else obj._io
+            key = self.ios.inverse.get(a_io)
+            if (key is not None and key[0] is not None
+                    and key[0] is not io_group):
+                continue
+            if kind == "spec":
+                self.del_spec(obj)
+            elif not obj.specs:     # "io"; keep while specs remain attached
+                self._del_io(obj)
 
     def _check_sanity(self):
         assert len(self.ios) == len(set(id(v) for v in self.ios.values()))
@@ -173,6 +215,8 @@ class IOManager:
         a_io = cls(path, self, load_from, **kwargs)
         if not self._get_io(io_group, a_io.path):
             self.ios[self._get_io_key(io_group, a_io.path)] = a_io
+            if self._journal is not None:
+                self._journal.append(("io", a_io))
             return a_io
         else:
             raise RuntimeError("must not happen")
@@ -225,6 +269,8 @@ class IOManager:
         if id(spec) not in io_.specs:
             if io_._can_add_spec(spec):
                 io_._specs[id(spec)] = spec
+                if self._journal is not None:
+                    self._journal.append(("spec", spec))
             else:
                 raise ValueError("cannot add spec")
 

--- a/modelx/serialize/custom_pickle.py
+++ b/modelx/serialize/custom_pickle.py
@@ -31,6 +31,9 @@ class IOSpecUnpickler(pickle.Unpickler):
         self.reader = reader
         self.manager = reader.system.iomanager
         self.model = reader.model
+        # Rollback point for load_pickle_tolerantly if this strict
+        # attempt aborts after registering ios/specs
+        reader.io_journal_mark = self.manager.journal_mark()
 
     def persistent_load(self, pid):
 
@@ -122,6 +125,9 @@ class ModelUnpickler(pickle.Unpickler):
         self.model = reader.model
         if reader.version >= 5:
             self.iospecs = reader.iospecs
+        # Rollback point for load_pickle_tolerantly if this strict
+        # attempt aborts after registering ios/specs
+        reader.io_journal_mark = self.manager.journal_mark()
 
     def _find_iospec(self, sp_id):
         # In the fast strict pass the error aborts the load and triggers

--- a/modelx/serialize/serializer_4.py
+++ b/modelx/serialize/serializer_4.py
@@ -1065,12 +1065,14 @@ class ModelReader:
         self.temproot = None
         self.error_ids = set()          # Keys of lost pickledata entries
         self.unpickle_errors = []       # Errors caught while unpickling
+        self.io_journal_mark = 0        # Set on each strict unpickling attempt
 
     def read_model(self, **kwargs):
 
         try:
             self.system.serializing = self
             self.system.iomanager.serializing = True
+            self.system.iomanager.begin_journal()
             self.kwargs = kwargs
 
             if (sys.platform == "win32"
@@ -1092,13 +1094,20 @@ class ModelReader:
                 model = self._read_model_inner()
 
         except:
-            if self.model:
-                self.model.close()
+            try:
+                if self.model:
+                    self.model.close()
+            finally:
+                # Discard ios/specs this read registered in the global
+                # iomanager; closing the model cannot see them until their
+                # refs are registered in the model's ValueRegistry
+                self.system.iomanager.rollback_journal(io_group=self.model)
             raise
 
         finally:
             self.system.serializing = None
             self.system.iomanager.serializing = None
+            self.system.iomanager.end_journal()
 
         return model
 

--- a/modelx/serialize/serializer_5.py
+++ b/modelx/serialize/serializer_5.py
@@ -1059,12 +1059,14 @@ class ModelReader:
         self.temproot = None
         self.error_ids = set()          # Keys of lost pickledata entries
         self.unpickle_errors = []       # Errors caught while unpickling
+        self.io_journal_mark = 0        # Set on each strict unpickling attempt
 
     def read_model(self, **kwargs):
 
         try:
             self.system.serializing = self
             self.system.iomanager.serializing = True
+            self.system.iomanager.begin_journal()
             self.kwargs = kwargs
 
             if (sys.platform == "win32"
@@ -1086,13 +1088,20 @@ class ModelReader:
                 model = self._read_model_inner()
 
         except:
-            if self.model:
-                self.model.close()
+            try:
+                if self.model:
+                    self.model.close()
+            finally:
+                # Discard ios/specs this read registered in the global
+                # iomanager; closing the model cannot see them until their
+                # refs are registered in the model's ValueRegistry
+                self.system.iomanager.rollback_journal(io_group=self.model)
             raise
 
         finally:
             self.system.serializing = None
             self.system.iomanager.serializing = None
+            self.system.iomanager.end_journal()
 
         return model
 

--- a/modelx/serialize/serializer_6.py
+++ b/modelx/serialize/serializer_6.py
@@ -871,12 +871,14 @@ class ModelReader:
         self.temproot = None
         self.error_ids = set()          # Keys of lost pickledata entries
         self.unpickle_errors = []       # Errors caught while unpickling
+        self.io_journal_mark = 0        # Set on each strict unpickling attempt
 
     def read_model(self, **kwargs):
 
         try:
             self.system.serializing = self
             self.system.iomanager.serializing = True
+            self.system.iomanager.begin_journal()
             self.kwargs = kwargs
 
             if (sys.platform == "win32"
@@ -898,13 +900,20 @@ class ModelReader:
                 model = self._read_model_inner()
 
         except:
-            if self.model:
-                self.model.close()
+            try:
+                if self.model:
+                    self.model.close()
+            finally:
+                # Discard ios/specs this read registered in the global
+                # iomanager; closing the model cannot see them until their
+                # refs are registered in the model's ValueRegistry
+                self.system.iomanager.rollback_journal(io_group=self.model)
             raise
 
         finally:
             self.system.serializing = None
             self.system.iomanager.serializing = None
+            self.system.iomanager.end_journal()
 
         return model
 

--- a/modelx/serialize/tolerant_pickle.py
+++ b/modelx/serialize/tolerant_pickle.py
@@ -282,19 +282,6 @@ def sweep_pickledata(data, contaminated=()):
     return error_keys
 
 
-def _reset_model_ios(reader):
-    # Discard IOs (and specs attached to them) registered by an aborted
-    # unpickling attempt, so a retry does not duplicate the specs.
-    # IOs keyed by absolute path may be shared with other models and are
-    # left to delete_orphan_ios, which only removes spec-less ones.
-    manager = reader.system.iomanager
-    for io_ in list(manager.get_ios(reader.model).values()):
-        for spec in list(io_.specs.values()):
-            manager.del_spec(spec)
-        if not io_.specs:
-            manager._del_io(io_)
-
-
 def load_pickle_tolerantly(reader, path, kind):
     """Load a pickle file substituting None for unrestorable values.
 
@@ -303,11 +290,15 @@ def load_pickle_tolerantly(reader, path, kind):
     keys on the reader. Returns an empty dict if the file cannot be parsed
     at all (e.g. a truncated stream).
     """
+    manager = reader.system.iomanager
+
     if kind == "iospecs" or reader.version < 5:
         # The aborted strict attempt may have registered IOs and attached
         # specs (from iospecs.pickle, or from data.pickle in v4 models
-        # where specs are pickled by value); discard them before retrying
-        _reset_model_ios(reader)
+        # where specs are pickled by value); discard them before retrying,
+        # including specs attached to absolute-path IOs, whose stale
+        # presence would veto the retried specs and null their refs
+        manager.rollback_journal(reader.io_journal_mark, io_group=reader.model)
 
     cls = TolerantModelUnpickler if kind == "model" else TolerantIOSpecUnpickler
     unpickler = None
@@ -317,11 +308,16 @@ def load_pickle_tolerantly(reader, path, kind):
         unpickler = cls(file, reader)
         return unpickler.load()
 
+    mark = manager.journal_mark()
     try:
         data = ziputil.read_file_utf8(loadfunc, path, "b")
         if not isinstance(data, dict):
             raise TypeError("unexpected data in '%s': %r" % (path, data))
     except Exception as exc:
+        # The whole file's values are lost; ios/specs the aborted
+        # tolerant attempt registered would otherwise outlive the read
+        # (their refs load as None, so nothing else removes them)
+        manager.rollback_journal(mark, io_group=reader.model)
         reader.unpickle_errors.append(exc)
         warnings.warn(
             "'%s' could not be read (%r); "

--- a/modelx/tests/serialize/test_read_error_cleanup.py
+++ b/modelx/tests/serialize/test_read_error_cleanup.py
@@ -1,0 +1,282 @@
+"""Failed model reads must not leave residue in the global IOManager.
+
+During a read, IOSpecs and SharedIOs are registered in the process-global
+IOManager before the __setattr__/set_ref batch makes them reachable from
+the model's ValueRegistry, so the error path's model.close() cannot see
+them. The readers journal every registration and roll the journal back
+when the read fails (see IOManager.rollback_journal), and the tolerant
+retry rolls back the aborted strict attempt's registrations so its stale
+specs cannot veto the retried ones (see
+tolerant_pickle.load_pickle_tolerantly).
+"""
+
+import warnings
+
+import pytest
+
+import modelx as mx
+from modelx.core.system import mxsys
+from modelx.serialize import serializer_6
+
+pd = pytest.importorskip("pandas")
+
+VERSIONS = [6, 7]
+
+
+@pytest.fixture
+def sample_df():
+    return pd.DataFrame({"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]})
+
+
+def _write_io_model(tmp_path, name, df, version, zipped=False):
+    """Write a model with an absolute-path and a relative-path PandasData.
+
+    The absolute-path spec is created first so it precedes the relative
+    one in iospecs.pickle: an aborted strict unpickling pass then has
+    already registered it, which is the trigger for the stale-twin bug
+    covered by test_tolerant_retry_keeps_healthy_abs_ref."""
+    m = mx.new_model(name)
+    s = m.new_space("Space1")
+    s.new_pandas(name="df_abs", path=str(tmp_path / "external" / "df_abs.csv"),
+                 data=df, file_type="csv")
+    s.new_pandas(name="df_rel", path="data/df_rel.csv",
+                 data=df.copy(), file_type="csv")
+    path = tmp_path / ("model.zip" if zipped else "model")
+    write = mx.zip_model if zipped else mx.write_model
+    write(m, str(path), version=version)
+    m.close()
+    return path
+
+
+class _InjectedError(Exception):
+    pass
+
+
+@pytest.fixture
+def fail_at(monkeypatch):
+    """Make the instruction batch containing a given method raise."""
+    def _install(method):
+        orig = serializer_6.CompoundInstruction.execute_selected_methods
+
+        def raising(self, methods, pop_executed=True):
+            if method in methods:
+                raise _InjectedError("injected failure")
+            return orig(self, methods, pop_executed)
+
+        monkeypatch.setattr(
+            serializer_6.CompoundInstruction,
+            "execute_selected_methods", raising)
+    return _install
+
+
+# "set_ref" fails before refs reach the ValueRegistry (rollback must
+# remove everything); "_set_dynamic_inputs" fails after (model.close()
+# removes the specs first and rollback must skip them); "add_bases"
+# fails before read_pickledata (empty journal).
+FAIL_METHODS = ["set_ref", "_set_dynamic_inputs", "add_bases"]
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+@pytest.mark.parametrize("fail_method", FAIL_METHODS)
+def test_failed_read_leaves_no_io_residue(
+        tmp_path, sample_df, version, fail_method, fail_at,
+        close_new_models):
+    """A failed read leaves the iomanager as it was before the read."""
+    path = _write_io_model(tmp_path, "LeakTest", sample_df, version)
+    baseline = set(mxsys.iomanager.ios)     # entries left by other tests
+    fail_at(fail_method)
+
+    with pytest.raises(_InjectedError):
+        mx.read_model(str(path))
+
+    assert set(mxsys.iomanager.ios) == baseline
+    assert "LeakTest" not in mx.get_models()
+    assert mxsys.serializing is None
+    assert mxsys.iomanager.serializing is None
+    assert mxsys.iomanager._journal is None
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_failed_read_zip_no_residue(
+        tmp_path, sample_df, version, fail_at, close_new_models):
+    """Same as above for a zipped model (temproot path)."""
+    path = _write_io_model(
+        tmp_path, "LeakTestZip", sample_df, version, zipped=True)
+    baseline = set(mxsys.iomanager.ios)
+    fail_at("set_ref")
+
+    with pytest.raises(_InjectedError):
+        mx.read_model(str(path))
+
+    assert set(mxsys.iomanager.ios) == baseline
+    assert mxsys.iomanager._journal is None
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_read_retry_after_failure(
+        tmp_path, sample_df, version, monkeypatch, close_new_models):
+    """Re-reading the same model after a failed read loads it intact."""
+    path = _write_io_model(tmp_path, "RetryTest", sample_df, version)
+    baseline = set(mxsys.iomanager.ios)
+
+    orig = serializer_6.CompoundInstruction.execute_selected_methods
+
+    def raising(self, methods, pop_executed=True):
+        if "set_ref" in methods:
+            raise _InjectedError("injected failure")
+        return orig(self, methods, pop_executed)
+
+    with monkeypatch.context() as mp:
+        mp.setattr(serializer_6.CompoundInstruction,
+                   "execute_selected_methods", raising)
+        with pytest.raises(_InjectedError):
+            mx.read_model(str(path))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        m = mx.read_model(str(path))
+
+    assert mxsys.iomanager._journal is None
+    pd.testing.assert_frame_equal(m.Space1.df_rel, sample_df)
+    pd.testing.assert_frame_equal(m.Space1.df_abs, sample_df)
+    assert len(m.iospecs) == 2
+
+    m.close()
+    assert set(mxsys.iomanager.ios) == baseline
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_failed_read_keeps_other_models_ios(
+        tmp_path, sample_df, version, fail_at, close_new_models):
+    """Rollback removes only the failed read's registrations."""
+    live = mx.new_model("LiveModel")
+    live.new_space("S").new_pandas(
+        name="df_live", path=str(tmp_path / "live" / "df_live.csv"),
+        data=sample_df, file_type="csv")
+
+    path = _write_io_model(tmp_path, "LeakTest2", sample_df, version)
+    baseline = set(mxsys.iomanager.ios)     # includes LiveModel's io
+    fail_at("set_ref")
+
+    with pytest.raises(_InjectedError):
+        mx.read_model(str(path))
+
+    assert set(mxsys.iomanager.ios) == baseline
+    assert len(live.iospecs) == 1
+    pd.testing.assert_frame_equal(live.S.df_live, sample_df)
+
+
+def test_rollback_keeps_other_groups(sample_df, close_new_models):
+    """A spec created on another model while a journal is active (e.g. by
+    module code executed during unpickling) survives a rollback scoped
+    to the reading model."""
+    live = mx.new_model("JournalLive")
+    reading = mx.new_model("JournalReading")
+    manager = mxsys.iomanager
+    baseline = set(manager.ios)
+
+    manager.begin_journal()
+    try:
+        mark = manager.journal_mark()
+        live.new_space("S").new_pandas(
+            name="df_live", path="data/df_live.csv",
+            data=sample_df, file_type="csv")
+        manager.rollback_journal(mark, io_group=reading)
+    finally:
+        manager.end_journal()
+
+    assert len(live.iospecs) == 1
+    pd.testing.assert_frame_equal(live.S.df_live, sample_df)
+
+    live.close()
+    reading.close()
+    assert set(manager.ios) == baseline
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_failed_read_keeps_shared_abs_io(
+        tmp_path, sample_df, version, fail_at, close_new_models):
+    """Rolling back a spec journaled on a pre-owned absolute-path io
+    keeps the io and the other model's spec."""
+    pytest.importorskip("openpyxl")
+    xlsx = str(tmp_path / "shared" / "shared.xlsx")
+
+    ma = mx.new_model("ShareA")
+    ma.new_space("S").new_pandas(
+        name="df_a", path=xlsx, data=sample_df, file_type="excel",
+        sheet="SA")
+    mb = mx.new_model("ShareB")
+    mb.new_space("S").new_pandas(
+        name="df_b", path=xlsx, data=sample_df.copy(), file_type="excel",
+        sheet="SB")
+
+    path_a = tmp_path / "model_a"
+    path_b = tmp_path / "model_b"
+    mx.write_model(ma, str(path_a), version=version)
+    mx.write_model(mb, str(path_b), version=version)
+    ma.close()
+    mb.close()
+
+    ma2 = mx.read_model(str(path_a))    # owns the shared abs io now
+    baseline = set(mxsys.iomanager.ios)
+    fail_at("set_ref")
+
+    with pytest.raises(_InjectedError):
+        mx.read_model(str(path_b))
+
+    assert set(mxsys.iomanager.ios) == baseline
+    assert len(ma2.iospecs) == 1
+    # check_dtype=False: the excel round-trip may narrow float columns
+    pd.testing.assert_frame_equal(ma2.S.df_a, sample_df, check_dtype=False)
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_tolerant_pass_abort_leaves_no_residue(
+        tmp_path, sample_df, version, close_new_models):
+    """When the tolerant retry itself dies (stream truncated past what
+    the wrapped opcode handlers tolerate), its registrations are rolled
+    back so the model stays readable once the file is repaired."""
+    path = _write_io_model(tmp_path, "AbortTest", sample_df, version)
+    baseline = set(mxsys.iomanager.ios)
+    iofile = path / "_data" / "iospecs.pickle"
+    pristine = iofile.read_bytes()
+    iofile.write_bytes(pristine[:-1])   # drop STOP: EOF after the specs
+                                        # have been registered
+
+    with pytest.warns(UserWarning, match="could not be read"):
+        m = mx.read_model(str(path))
+    assert m.Space1.df_abs is None
+    assert m.Space1.df_rel is None
+    m.close()
+    assert set(mxsys.iomanager.ios) == baseline
+
+    iofile.write_bytes(pristine)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        m2 = mx.read_model(str(path))
+    pd.testing.assert_frame_equal(m2.Space1.df_abs, sample_df)
+    pd.testing.assert_frame_equal(m2.Space1.df_rel, sample_df)
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_tolerant_retry_keeps_healthy_abs_ref(
+        tmp_path, sample_df, version, close_new_models):
+    """A strict-pass abort must not null refs whose specs are healthy.
+
+    Deleting the file behind the relative-path spec aborts the strict
+    iospecs pass; the absolute-path spec registered by that aborted pass
+    used to survive as a stale twin that vetoed its retried self, so the
+    healthy df_abs ref came back None."""
+    path = _write_io_model(tmp_path, "AbsKeepTest", sample_df, version)
+    baseline = set(mxsys.iomanager.ios)
+    (path / "data" / "df_rel.csv").unlink()
+
+    with pytest.warns(UserWarning, match="could not be restored"):
+        m = mx.read_model(str(path))
+
+    assert m.Space1.df_rel is None
+    pd.testing.assert_frame_equal(m.Space1.df_abs, sample_df)
+    assert len(m.iospecs) == 1
+
+    m.close()
+    assert set(mxsys.iomanager.ios) == baseline


### PR DESCRIPTION
## What changed

`IOManager` gains a registration journal, active only while a `ModelReader` (serializers 4–7) is running: every `SharedIO` created and every `IOSpec` attached is recorded. The journal is used at three points:

- **`read_model` failure** (serializer_4/5/6; 7 inherits 6): after closing the half-built model, the reader rolls the journal back, removing exactly the entries `close()` cannot see — specs whose refs never reached the model's `ValueRegistry`. The rollback runs in a `try/finally` around `close()` and is scoped to the reading model's io group, so specs another live model gains as a side effect of module execution during unpickling are kept.
- **Tolerant retry** (`load_pickle_tolerantly`): the strict unpicklers record a journal mark at construction, and the pre-retry cleanup rolls back to that mark, replacing `_reset_model_ios`. Unlike that helper, this also detaches the aborted strict pass's specs from shared absolute-path IOs.
- **Aborted tolerant pass**: if the tolerant unpickler itself dies (e.g. a truncated stream raising EOFError outside the wrapped opcode handlers), its except branch now rolls back the registrations that attempt made.

## Why

Any read failure between `read_pickledata` (which registers specs/IOs in the process-global `IOManager`) and the `__setattr__`/`set_ref` batch (which makes them reachable from the `ValueRegistry`) leaked those entries for the rest of the session:

- relative-path IOs, keyed by the dead model's interface, pinned the entire closed half-built model and its loaded DataFrames in memory, accumulating per failed read;
- absolute-path IOs, keyed `(None, path)`, were rewritten to disk by `write_ios` on **every later save of any model** — a deleted external file reappeared with stale data;
- retrying the same valid model collided with the stale spec (`ValueError('cannot add spec')`), which tolerant unpickling swallowed, silently restoring the ref as `None`; recovery required a process restart.

The tolerant-retry variant needed no fatal failure at all: `_reset_model_ios` deliberately skipped absolute-path IOs, so the aborted strict pass's spec vetoed its retried twin and a **healthy** absolute-path ref loaded as `None` even though its file was intact.

All defects were confirmed with executed repros before the fix was written.

## Reviewer notes

- `modelx/tests/serialize/test_read_error_cleanup.py` adds 19 test instances: failure injected at `set_ref` (pre-registry), `_set_dynamic_inputs` (post-registry double-clean), and `add_bases` (empty journal); the zip/temproot path; retry-after-failure loading intact with zero warnings; a live model's IOs surviving another model's failed read, including a shared absolute-path xlsx where only the spec is journaled; a group-scoping unit test; the truncated-stream tolerant-abort case; and the stale-twin absolute-path-ref case. The core tests were verified to fail on pre-fix code.
- Full suite: 1128 passed, 6 skipped on py313 (Windows).
- Public surfaces are unchanged (`_reset_model_ios` was module-private); `devnotes/DependentPackages.md` was checked — spymx-kernels and modelx-cython do not touch the modified internals.
- Heads-up: the companion fix for the `_BAK`-rename/`cur_model()` restoration on failed loads (branch `claude/exciting-golick-e94327`) edits the same `read_model` except blocks; whichever merges second will hit a small, mechanical conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)