### PR TITLE
Restore displaced and current models when a model load fails

### DIFF
--- a/modelx/serialize/reader_state.py
+++ b/modelx/serialize/reader_state.py
@@ -1,0 +1,40 @@
+"""Restore the system's models when a model read fails.
+
+``ModelReader.read_model`` for serializer versions 4-7 builds the new
+model in the live system: ``parse_dir`` creates a model (making it
+current), and ``RenameParser`` renames it to its saved name immediately
+during parsing, displacing a same-named existing model to
+``<name>_BAK<n>``.  When the read fails halfway, closing the half-built
+model does not undo those side effects on its own: the displaced model
+would stay under its backup name, and no model would be current even
+though the previously current model still exists.
+
+``SystemStateSnapshot`` records the state before the read so that the
+except path can put it back after closing the half-built model.  On a
+successful read the displaced model intentionally keeps its backup name,
+so the snapshot is simply discarded.
+"""
+
+
+class SystemStateSnapshot:
+
+    def __init__(self, system):
+        self.system = system
+        self.models = dict(system.models)
+        self.currentmodel = system.currentmodel
+
+    def restore(self):
+        """Called after a failed read, once the half-built model is closed."""
+        system = self.system
+
+        for name, model in self.models.items():
+            if (model.name != name
+                    and system.models.get(model.name) is model
+                    and name not in system.models):
+                system.rename_model(new_name=name, old_name=model.name)
+
+        current = self.currentmodel
+        if (system.currentmodel is None
+                and current is not None
+                and system.models.get(current.name) is current):
+            system.currentmodel = current

--- a/modelx/serialize/serializer_4.py
+++ b/modelx/serialize/serializer_4.py
@@ -33,6 +33,7 @@ from modelx.io.baseio import BaseIOSpec
 import asttokens
 from . import ziputil
 from .custom_pickle import ModelUnpickler, ModelPickler
+from .reader_state import SystemStateSnapshot
 
 
 Section = namedtuple("Section", ["id", "symbol"])
@@ -1069,6 +1070,7 @@ class ModelReader:
 
     def read_model(self, **kwargs):
 
+        state = SystemStateSnapshot(self.system)
         try:
             self.system.serializing = self
             self.system.iomanager.serializing = True
@@ -1102,6 +1104,7 @@ class ModelReader:
                 # iomanager; closing the model cannot see them until their
                 # refs are registered in the model's ValueRegistry
                 self.system.iomanager.rollback_journal(io_group=self.model)
+            state.restore()
             raise
 
         finally:

--- a/modelx/serialize/serializer_5.py
+++ b/modelx/serialize/serializer_5.py
@@ -34,6 +34,7 @@ from . import ziputil
 from .custom_pickle import (
     IOSpecUnpickler, ModelUnpickler,
     IOSpecPickler, ModelPickler)
+from .reader_state import SystemStateSnapshot
 
 
 Section = namedtuple("Section", ["id", "symbol"])
@@ -1063,6 +1064,7 @@ class ModelReader:
 
     def read_model(self, **kwargs):
 
+        state = SystemStateSnapshot(self.system)
         try:
             self.system.serializing = self
             self.system.iomanager.serializing = True
@@ -1096,6 +1098,7 @@ class ModelReader:
                 # iomanager; closing the model cannot see them until their
                 # refs are registered in the model's ValueRegistry
                 self.system.iomanager.rollback_journal(io_group=self.model)
+            state.restore()
             raise
 
         finally:

--- a/modelx/serialize/serializer_6.py
+++ b/modelx/serialize/serializer_6.py
@@ -36,6 +36,7 @@ from .deserializer import (
 from .custom_pickle import (
     IOSpecUnpickler, ModelUnpickler,
     IOSpecPickler, ModelPickler)
+from .reader_state import SystemStateSnapshot
 
 
 class TupleID(tuple):
@@ -875,6 +876,7 @@ class ModelReader:
 
     def read_model(self, **kwargs):
 
+        state = SystemStateSnapshot(self.system)
         try:
             self.system.serializing = self
             self.system.iomanager.serializing = True
@@ -908,6 +910,7 @@ class ModelReader:
                 # iomanager; closing the model cannot see them until their
                 # refs are registered in the model's ValueRegistry
                 self.system.iomanager.rollback_journal(io_group=self.model)
+            state.restore()
             raise
 
         finally:

--- a/modelx/tests/serialize/test_read_error_recovery.py
+++ b/modelx/tests/serialize/test_read_error_recovery.py
@@ -1,0 +1,103 @@
+"""Failed model reads must not disturb pre-existing models.
+
+``read_model`` for serializer versions 4-7 builds the new model in the
+live system, renaming it to its saved name during parsing and thereby
+displacing a same-named existing model to ``<name>_BAK<n>``.  When the
+read fails partway, besides closing the half-built model, the reader
+must rename the displaced model back and make the previously current
+model current again (see modelx/serialize/reader_state.py).
+
+The corruption used here truncates a space file mid-statement: the root
+``__init__.py`` (holding ``_name``) parses fine, so the load aborts
+after the displacing rename has already happened - the worst case.
+"""
+
+import pathlib
+import shutil
+import tokenize
+import warnings
+
+import pytest
+
+import modelx as mx
+from modelx.tests.testdata.serializer_compat import fixturemodel
+
+DATADIR = pathlib.Path(fixturemodel.__file__).parent
+
+VERSIONS = [4, 5, 6, 7]
+
+PARSE_ERRORS = (SyntaxError, tokenize.TokenError)
+
+
+def _copy_and_corrupt(version, tmp_path):
+    src = DATADIR / ("model_v%s" % version)
+    dst = tmp_path / src.name
+    shutil.copytree(str(src), str(dst))
+    spacefile = dst / "Base" / "__init__.py"
+    spacefile.write_text(spacefile.read_text() + "\nbroken = (\n")
+    return dst
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_failed_read_restores_displaced_model(
+        version, tmp_path, close_new_models):
+    """The displaced same-named model gets its original name back."""
+    existing = mx.new_model("SerializerCompat")
+    names_before = set(mx.get_models())
+    path = _copy_and_corrupt(version, tmp_path)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(PARSE_ERRORS):
+            mx.read_model(str(path))
+
+    # The read did rename the existing model away before failing
+    assert any("renamed to" in str(w.message) for w in caught)
+
+    assert mx.get_models().get("SerializerCompat") is existing
+    assert set(mx.get_models()) == names_before
+    assert mx.cur_model() is existing
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_failed_read_restores_current_model(
+        version, tmp_path, close_new_models):
+    """The previously current model is current again after a failed read."""
+    prior = mx.new_model("PriorModel")
+    names_before = set(mx.get_models())
+    path = _copy_and_corrupt(version, tmp_path)
+
+    with pytest.raises(PARSE_ERRORS):
+        mx.read_model(str(path))
+
+    assert mx.cur_model() is prior
+    assert set(mx.get_models()) == names_before
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_failed_read_without_prior_models(
+        version, tmp_path, close_new_models):
+    """A failed read leaves whatever was there before untouched."""
+    names_before = set(mx.get_models())
+    cur_before = mx.cur_model()
+    path = _copy_and_corrupt(version, tmp_path)
+
+    with pytest.raises(PARSE_ERRORS):
+        mx.read_model(str(path))
+
+    assert set(mx.get_models()) == names_before
+    assert mx.cur_model() is cur_before
+
+
+@pytest.mark.parametrize("version", VERSIONS)
+def test_successful_read_still_displaces(version, tmp_path, close_new_models):
+    """On success the displaced model intentionally keeps its backup name."""
+    existing = mx.new_model("SerializerCompat")
+
+    with pytest.warns(UserWarning, match="renamed to"):
+        m = mx.read_model(str(DATADIR / ("model_v%s" % version)))
+
+    assert mx.get_models().get("SerializerCompat") is m
+    assert existing.name.startswith("SerializerCompat_BAK")
+    assert mx.cur_model() is m
+    fixturemodel.check_fixture_model(m)


### PR DESCRIPTION
## What changed

`ModelReader.read_model` (serializers 4-7) now restores the system's pre-existing models when a load fails partway:

- **Displaced model gets its name back.** `RenameParser` runs at `AT_PARSE` and renames the half-built model to its saved name immediately during parsing, displacing a same-named existing model to `<name>_BAK<n>`. Previously, a failed read closed only the half-built model, leaving the user's model stranded under the backup name with nothing under the original name.
- **The previously current model becomes current again.** `parse_dir`'s `mx.new_model()` makes the half-built model current, and `close_model` nulls `currentmodel` instead of restoring the prior one — so after any failed read, `mx.cur_model()` was `None` and the next current-model-dependent call (e.g. `mx.defcells`, `mx.new_space`) silently created a brand-new model.

The fix is shared: a new `modelx/serialize/reader_state.py` defines `SystemStateSnapshot`, which records `system.models` and `system.currentmodel` before each read; the `except` paths of serializer 4/5/6 (7 inherits 6) call `state.restore()` after closing the half-built model and rolling back the IOManager journal (#256). Restoration is guarded by identity checks so it only renames back a model this read displaced, and only when the original name is free.

Successful reads are unchanged: the displaced model intentionally keeps its `_BAK` name (covered by the existing `test_restore_model_leave_old`).

## Tests

New `modelx/tests/serialize/test_read_error_recovery.py` (16 tests, versions 4-7). The failure is produced without mocks by truncating a space file mid-statement in a copy of the compat fixtures, so the load aborts after the displacing rename — the worst-case failure point. Scenarios: displaced model restored by identity under its original name, prior `cur_model()` restored, no-prior-model reads left untouched, and the success path still displacing to `_BAK`.

Without the fix, 8 of the 16 fail (both defects, all four versions); with it, the full suite is green (1144 passed, 6 skipped).

## Notes for review

- Branch is rebased onto #256 (`1ab0bcf`), which restructured the same `except` blocks; `state.restore()` runs after that fix's `close()` + `rollback_journal` block, before `raise`.
- Scoped deliberately to rename/currentmodel restoration; the IOManager leak was fixed separately in #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)