### PR TITLE
MAINT: Collapse repr_parent overrides into an Impl default

### DIFF
--- a/modelx/core/base.py
+++ b/modelx/core/base.py
@@ -253,7 +253,10 @@ class Impl(BaseImpl):
         raise NotImplementedError
 
     def repr_parent(self):
-        raise NotImplementedError
+        # ItemSpaceImpl overrides this to skip one level, because its
+        # repr_self embeds the parent's name ("Space[1]"); ModelImpl
+        # terminates the recursion with "".
+        return self.parent.get_repr(fullname=True)
 
     def get_repr(self, fullname=False, add_params=True):
 

--- a/modelx/core/cells.py
+++ b/modelx/core/cells.py
@@ -740,9 +740,6 @@ class CellsImpl(*_cells_impl_base):
         else:
             return self.name
 
-    def repr_parent(self):
-        return self.parent.repr_parent() + "." + self.parent.repr_self()
-
     def has_node(self, key):
         return key in self.data
 

--- a/modelx/core/macro.py
+++ b/modelx/core/macro.py
@@ -192,13 +192,6 @@ class MacroImpl(Impl):
             func = Formula(func, name=self.name)
         self.formula = func
     
-    def repr_parent(self):
-        """Return parent representation"""
-        if self.parent.repr_parent():
-            return self.parent.repr_parent() + "." + self.parent.repr_self()
-        else:
-            return self.parent.repr_self()
-    
     def repr_self(self, add_params=True):
         """Return self representation"""
         return self.name

--- a/modelx/core/reference.py
+++ b/modelx/core/reference.py
@@ -58,12 +58,6 @@ class ReferenceImpl(Derivable, Impl):
     def to_node(self):
         return ReferenceNode(get_node(self, None, None))
 
-    def repr_parent(self):
-        if self.parent.repr_parent():
-            return self.parent.repr_parent() + "." + self.parent.repr_self()
-        else:
-            return self.parent.repr_self()
-
     def repr_self(self, add_params=True):
         return self.name
 

--- a/modelx/core/space.py
+++ b/modelx/core/space.py
@@ -2096,12 +2096,6 @@ class BaseSpaceImpl(*_base_space_impl_base):
     def repr_self(self, add_params=True):
         return self.name
 
-    def repr_parent(self):
-        if self.parent.repr_parent():
-            return self.parent.repr_parent() + "." + self.parent.repr_self()
-        else:
-            return self.parent.repr_self()
-
     # ----------------------------------------------------------------------
     # Pandas, Module, Excel I/O
 

--- a/modelx/tests/core/node/test_node_attrdict.py
+++ b/modelx/tests/core/node/test_node_attrdict.py
@@ -1,0 +1,54 @@
+"""Guard the ``repr_parent`` key in node attribute dicts.
+
+``BaseNode._baseattrs`` and ``BaseNode._get_attrdict`` are wire formats
+consumed by spyder-modelx: MxAnalyzer splits ``node["repr_parent"]`` on
+"." to build its Model/Space columns (see devnotes/DependentPackages.md;
+the schema is additive-only).  An ItemSpace embeds its parent's name in
+its own repr ("Space[1]"), so its repr_parent skips the parent space:
+nodes under ``Space[1]`` must report "Model.Space[1]", not "Model.Space",
+and the node for ``Space[1]`` itself must report "Model".
+"""
+
+import modelx as mx
+
+import pytest
+
+
+@pytest.fixture
+def testmodel():
+
+    m = mx.new_model('Model')
+    s = m.new_space('Space', formula=lambda i: None)
+    s.new_cells('foo', formula=lambda x: x)
+    s.new_space('Child', formula=lambda j: None).new_cells(
+        'bar', formula=lambda y: y)
+
+    # Compute values so that preds/succs in the attribute dicts work
+    m.Space.foo(1)
+    m.Space.Child.bar(2)
+    m.Space[1].foo(2)
+    m.Space[1].Child[2].bar(3)
+
+    yield m
+    m._impl._check_sanity()
+    m.close()
+
+
+params = [
+    (lambda m: m.Space.foo.node(1), "Model.Space"),
+    (lambda m: m.Space.Child.bar.node(2), "Model.Space.Child"),
+    (lambda m: m.Space.node(1), "Model"),
+    (lambda m: m.Space[1].foo.node(2), "Model.Space[1]"),
+    (lambda m: m.Space[1].Child.node(2), "Model.Space[1]"),
+    (lambda m: m.Space[1].Child[2].bar.node(3), "Model.Space[1].Child[2]"),
+]
+
+
+@pytest.mark.parametrize("get_node, expected", params)
+def test_baseattrs_repr_parent(testmodel, get_node, expected):
+    assert get_node(testmodel)._baseattrs["repr_parent"] == expected
+
+
+@pytest.mark.parametrize("get_node, expected", params)
+def test_attrdict_repr_parent(testmodel, get_node, expected):
+    assert get_node(testmodel)._get_attrdict()["repr_parent"] == expected


### PR DESCRIPTION
## Summary

- Add `modelx/tests/core/node/test_node_attrdict.py` to guard the `repr_parent` key in `BaseNode._baseattrs` / `BaseNode._get_attrdict` (`modelx/core/node.py`). This key is a wire-format contract: spyder-modelx's MxAnalyzer splits `node["repr_parent"]` on `"."` to build its Model/Space columns (see `devnotes/DependentPackages.md`, which rates the node attrdict schema high-risk / additive-only), but no test covered it — the spyder-surface snapshot only covers Interface dicts.
- Collapse the four hand-written generic `repr_parent` bodies (`BaseSpaceImpl`, `CellsImpl`, `ReferenceImpl`, `MacroImpl`) into a single base-class default on `Impl`: `return self.parent.get_repr(fullname=True)`. Only the two overrides that carry real behavior remain: `ItemSpaceImpl` (skips one ancestor level because its `repr_self` embeds the parent's name, e.g. `"Space[1]"`) and `ModelImpl` (terminates the recursion with `""`).

## Equivalence

The guarded form (`if parent.repr_parent(): parent.repr_parent() + "." + parent.repr_self() else: parent.repr_self()`) is exactly what `get_repr(fullname=True)` computes: the empty branch fires only when the parent is a Model (`get_repr`'s `is_model()` case), and every non-model parent's `repr_parent` is non-empty since chains terminate at the model name. `CellsImpl`'s unguarded copy was safe only because cells never sit directly in a model; the base default now handles that case uniformly.

The test lands first so the refactor commit is verified against the pinned contract, including the ItemSpace embed-and-skip grammar: `repr_parent` is `"Model"` for the `Space[1]` node itself and `"Model.Space[1]"` (not `"Model.Space"`) for nodes under it, down to a nested `Space[1].Child[2]`.

## Test plan

- New: `pytest modelx/tests/core/node/test_node_attrdict.py` (12 tests, both `_baseattrs` and `_get_attrdict` paths)
- Full suite: `pytest modelx/tests` — 1156 passed, 6 skipped (only pre-existing lifelib `SyntaxWarning`s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
