### PR TITLE
FIX: Invalidate namespace after Cells rename

### DIFF
--- a/modelx/core/edit/pipeline.py
+++ b/modelx/core/edit/pipeline.py
@@ -337,6 +337,7 @@ class RenameCells(Edit):
         for space in model.spmgr._get_subs(self.cells.parent,
                                            skip_self=False):
             txn.mark_dirty_base(space)
+            txn.mark_dirty(space, "cells")
             space.cells[old_name].on_rename(self.name, txn)
 
 

--- a/modelx/core/edit/pipeline.py
+++ b/modelx/core/edit/pipeline.py
@@ -337,7 +337,11 @@ class RenameCells(Edit):
         for space in model.spmgr._get_subs(self.cells.parent,
                                            skip_self=False):
             txn.mark_dirty_base(space)
-            txn.mark_dirty(space, "cells")
+            # Unlike RenameSpace, deliberately not mark_dirty: a
+            # dirty_spaces entry would clear itemspaces built on
+            # foreign dynbases (test_survive_rename_of_parent_cells);
+            # the rename rebinds a namespace key, so notify only.
+            txn.mark_dirty_container(space, "cells")
             space.cells[old_name].on_rename(self.name, txn)
 
 

--- a/modelx/core/edit/transaction.py
+++ b/modelx/core/edit/transaction.py
@@ -44,21 +44,26 @@ class ChangeSet:
                                     # treat values inside the deleted
                                     # trees as already invalid
         self.modified = []          # impls rebound/changed in place
-        self.dirty_containers = {}  # (parent_impl, attr) -> None
+        self.dirty_containers = {}  # (parent_impl, attr) -> None:
+                                    # containers whose namespace gets
+                                    # one batched notify in finalize;
+                                    # entered with (mark_dirty) or
+                                    # without (mark_dirty_container) a
+                                    # dirty_spaces entry
         self.dirty_spaces = {}      # idstr -> space_impl: spaces whose
-                                    # namespace bindings this edit
-                                    # changed (incl. removed spaces);
+                                    # members this edit added or
+                                    # removed (incl. removed spaces);
                                     # intersected with the FULL closure
                                     # (dynbases + MRO bases + parent
                                     # chain) by the itemspace
                                     # invalidation (§5.8)
         self.dirty_bases = {}       # idstr -> space_impl: spaces whose
-                                    # members changed only in place
-                                    # (formula changes, renames);
-                                    # intersected with the recorded
-                                    # dynbases only, preserving the
-                                    # per-dynbase selectivity these
-                                    # edits always had
+                                    # members changed without being
+                                    # added or removed (formula
+                                    # changes, renames); intersected
+                                    # with the recorded dynbases only,
+                                    # preserving the per-dynbase
+                                    # selectivity these edits always had
         self.finalize_ops = []      # edit-specific zero-arg callables run
                                     # post-commit, between deletions and
                                     # the batched notify
@@ -188,9 +193,19 @@ class Transaction:
         if not parent.is_model():
             self.changes.dirty_spaces[parent.idstr] = parent
 
+    def mark_dirty_container(self, parent, attr):
+        """Queue a namespace notify for ``parent``'s ``attr`` container
+        without entering ``dirty_spaces``. Cells renames rebind a
+        namespace key, so the namespace must be notified (GH220), but
+        their itemspace invalidation must stay per-dynbase selective
+        through ``mark_dirty_base`` — a ``dirty_spaces`` entry would
+        clear itemspaces built on foreign dynbases through the
+        full-closure intersection (§5.8)."""
+        self.changes.dirty_containers[(parent, attr)] = None
+
     def mark_dirty_base(self, space):
         """Record ``space`` in ``dirty_bases``: for edits (formula
-        changes, renames) that alter no namespace binding but stale the
+        changes, renames) that add or remove no member but stale the
         itemspace trees built on ``space``."""
         self.changes.dirty_bases[space.idstr] = space
 

--- a/modelx/core/itemspaces.py
+++ b/modelx/core/itemspaces.py
@@ -34,11 +34,13 @@ class ItemSpaceManager:
 
     On finalize an itemspace is cleared iff:
 
-    - ``ChangeSet.dirty_spaces`` (spaces whose namespace bindings
-      changed) intersects the full closure, or
-    - ``ChangeSet.dirty_bases`` (formula changes and renames, which
-      alter no bindings) intersects the recorded dynbases only —
-      preserving the per-dynbase selectivity these edits always had.
+    - ``ChangeSet.dirty_spaces`` (spaces with members added or
+      removed) intersects the full closure, or
+    - ``ChangeSet.dirty_bases`` (formula changes and renames — the
+      latter rebind a namespace key, notified via ``dirty_containers``,
+      but neither adds nor removes a member) intersects the recorded
+      dynbases only — preserving the per-dynbase selectivity these
+      edits always had.
 
     This refines §5.8's parent-granularity formula per itemspace, so an
     edit to one dynbase spares sibling itemspaces built on other

--- a/modelx/tests/core/cells/test_rename.py
+++ b/modelx/tests/core/cells/test_rename.py
@@ -1,6 +1,8 @@
 import modelx as mx
 import pytest
 
+from modelx.core.errors import FormulaError
+
 
 def test_rename(sample_for_rename_and_formula):
     """
@@ -54,9 +56,18 @@ def test_rename_funcname():
     m.close()
 
 
-def test_rename_invalidates_namespace():
-    model = mx.new_model()
-    space = model.new_space("Space")
+@pytest.fixture
+def rename_ns_model():
+    m = mx.new_model()
+    yield m
+    m._impl._check_sanity()
+    m.close()
+
+
+def test_rename_rebinds_namespace(rename_ns_model):
+    """Renaming rebinds the space's namespace: the old name stops
+    resolving and the new name resolves (GH220)."""
+    space = rename_ns_model.new_space("Space")
 
     @mx.defcells(space=space)
     def foo(x):
@@ -70,8 +81,39 @@ def test_rename_invalidates_namespace():
 
     space.foo.rename("foo_renamed")
 
-    assert not space._impl._is_ns_updated
-    assert "foo" not in space._impl.ns_dict
-    assert space._impl.ns_dict["foo_renamed"](3) == 6
+    # bar's formula still references the old name; it must fail
+    # loudly instead of evaluating against the stale binding (GH220).
+    with pytest.raises(FormulaError):
+        space.bar(3)
 
-    model.close()
+    assert space.foo_renamed(3) == 6
+
+    def baz(x):
+        return foo_renamed(x) + 10
+
+    space.new_cells(name="baz", formula=baz)
+    assert space.baz(3) == 16
+
+
+def test_rename_rebinds_sub_space_namespace(rename_ns_model):
+    """Renaming a base cells rebinds the namespaces of derived sub
+    spaces, not only the edited space's own."""
+    base = rename_ns_model.new_space("Base")
+
+    @mx.defcells(space=base)
+    def foo(x):
+        return x * 2
+
+    @mx.defcells(space=base)
+    def bar(x):
+        return foo(x) + 1
+
+    sub = rename_ns_model.new_space("Sub", bases=base)
+    assert sub.bar(3) == 7
+
+    base.foo.rename("foo_renamed")
+
+    with pytest.raises(FormulaError):
+        sub.bar(3)
+
+    assert sub.foo_renamed(5) == 10

--- a/modelx/tests/core/cells/test_rename.py
+++ b/modelx/tests/core/cells/test_rename.py
@@ -52,3 +52,26 @@ def test_rename_funcname():
 
     m._impl._check_sanity()
     m.close()
+
+
+def test_rename_invalidates_namespace():
+    model = mx.new_model()
+    space = model.new_space("Space")
+
+    @mx.defcells(space=space)
+    def foo(x):
+        return x * 2
+
+    @mx.defcells(space=space)
+    def bar(x):
+        return foo(x) + 1
+
+    assert space.bar(3) == 7
+
+    space.foo.rename("foo_renamed")
+
+    assert not space._impl._is_ns_updated
+    assert "foo" not in space._impl.ns_dict
+    assert space._impl.ns_dict["foo_renamed"](3) == 6
+
+    model.close()

--- a/modelx/tests/core/execution/test_selective_invalidation.py
+++ b/modelx/tests/core/execution/test_selective_invalidation.py
@@ -343,10 +343,15 @@ def test_survive_formula_change_on_parent_cells(foreign_dynbase_parent):
 def test_survive_rename_of_parent_cells(foreign_dynbase_parent):
     m, X, P, p1 = foreign_dynbase_parent
 
+    assert p1.xc(3) == 3    # warm the survivor's cache
+
     P.foo.rename("bar")
 
     assert p1._is_valid()
     assert len(P._named_itemspaces) == 1
+    # The survivor is still usable and its cached value is retained
+    assert p1.xc(3) == 3
+    assert len(p1.xc._impl.data) == 1
 
 
 def test_cleared_on_formula_change_in_foreign_dynbase(foreign_dynbase_parent):


### PR DESCRIPTION
Closes #220

`Cells.rename()` updated each space's cells mapping without invalidating its cached namespace, so formulas could keep resolving the old name. This marks affected spaces dirty through the existing transaction pipeline, rebuilding their namespace with only the renamed binding.

Regression coverage confirms the old binding is removed and the new binding resolves after rename.

Tests: `python -m pytest modelx/tests/core/cells -q` (117 passed, 1 skipped). Flake8 reports the same four pre-existing findings with and without this change.
