### PR TITLE
FIX: Reject Cells renames that collide with sub-space members

### DIFF
--- a/modelx/core/edit/pipeline.py
+++ b/modelx/core/edit/pipeline.py
@@ -332,6 +332,20 @@ class RenameCells(Edit):
                 self.cells.bases[0].get_repr(
                     fullname=True, add_params=False)))
 
+        # _can_add tolerates a colliding CellsImpl in sub spaces because
+        # for NewCells the sub's defined cells legitimately becomes an
+        # override. Rename instead rewrites every sub's entry in place,
+        # so any member under the new name in any sub would be silently
+        # overwritten and lost; reject the rename outright.
+        other = model.spmgr._find_name_in_subs(
+            self.cells.parent, self.name, skip_self=True)
+        if other is not None:
+            raise ValueError(
+                "cannot rename '%s' to '%s': '%s' is already defined" % (
+                    self.cells.get_repr(fullname=True, add_params=False),
+                    self.name,
+                    other.get_repr(fullname=True, add_params=False)))
+
     def apply(self, model, txn):
         old_name = self.cells.name
         for space in model.spmgr._get_subs(self.cells.parent,

--- a/modelx/core/edit/transaction.py
+++ b/modelx/core/edit/transaction.py
@@ -139,9 +139,21 @@ class Transaction:
         container[key] = container.pop(key)
 
     def rename_item(self, container, old_key, new_key):
-        """Rename ``old_key`` to ``new_key`` keeping its position."""
-        self._journal.append(("rename", container, old_key, new_key))
+        """Rename ``old_key`` to ``new_key`` keeping its position.
+
+        ``new_key`` must not be present: the journal records keys only,
+        so an overwrite could not be rolled back. Validation must
+        reject colliding renames before apply reaches this point.
+        """
+        if new_key in container:
+            raise RuntimeError(
+                "cannot rename '%s' to '%s': key already present"
+                % (old_key, new_key))
+        # Journal only after the mutation succeeds: a record for a
+        # rename that never happened would crash the reverse replay
+        # and strand every earlier write in the journal.
         _rename_item(container, old_key, new_key)
+        self._journal.append(("rename", container, old_key, new_key))
 
     def sort_items(self, container, sorted_keys=None):
         """Sort ``container`` keys (all, or the ``sorted_keys`` part)."""

--- a/modelx/tests/core/cells/test_rename.py
+++ b/modelx/tests/core/cells/test_rename.py
@@ -117,3 +117,114 @@ def test_rename_rebinds_sub_space_namespace(rename_ns_model):
         sub.bar(3)
 
     assert sub.foo_renamed(5) == 10
+
+
+def test_rename_to_sub_defined_cells_rejected(rename_ns_model):
+    """Renaming a base cells onto a name owned by a sub's own defined
+    cells must be rejected instead of silently destroying it."""
+    m = rename_ns_model
+    A = m.new_space("A")
+    A.new_cells(name="foo", formula=lambda x: x)
+    B = m.new_space("B", bases=A)
+    B.new_cells(name="baz", formula=lambda x: x + 100)
+    assert B.baz(1) == 101
+
+    with pytest.raises(
+            ValueError,
+            match=r"cannot rename '.*A\.foo' to 'baz': "
+                  r"'.*B\.baz' is already defined"):
+        A.foo.rename("baz")
+
+    assert B.baz(1) == 101
+    assert B.baz._impl.is_defined()
+    assert list(A._impl.cells) == ["foo"]
+    assert sorted(B._impl.cells) == ["baz", "foo"]
+
+
+def test_rename_to_other_base_cells_rejected(rename_ns_model):
+    """Renaming onto a name a sub derives from another base must be
+    rejected: the sub's derived copy would be overwritten and the
+    inheritance links left inconsistent."""
+    m = rename_ns_model
+    A = m.new_space("A")
+    A.new_cells(name="foo", formula=lambda x: x)
+    A2 = m.new_space("A2")
+    A2.new_cells(name="qux", formula=lambda x: x + 200)
+    B = m.new_space("B", bases=[A, A2])
+    assert B.qux(1) == 201
+
+    with pytest.raises(
+            ValueError,
+            match=r"cannot rename '.*A\.foo' to 'qux': "
+                  r"'.*B\.qux' is already defined"):
+        A.foo.rename("qux")
+
+    assert B.qux(1) == 201
+    assert list(A._impl.cells) == ["foo"]
+
+
+def test_rename_to_deep_sub_defined_cells_rejected(rename_ns_model):
+    """The collision check reaches subs of subs."""
+    m = rename_ns_model
+    A = m.new_space("A")
+    A.new_cells(name="foo", formula=lambda x: x)
+    B = m.new_space("B", bases=A)
+    C = m.new_space("C", bases=B)
+    C.new_cells(name="baz", formula=lambda x: x + 300)
+    assert C.baz(1) == 301
+
+    with pytest.raises(
+            ValueError,
+            match=r"cannot rename '.*A\.foo' to 'baz': "
+                  r"'.*C\.baz' is already defined"):
+        A.foo.rename("baz")
+
+    assert C.baz(1) == 301
+    assert list(A._impl.cells) == ["foo"]
+
+
+def test_rename_base_with_sub_override(rename_ns_model):
+    """Renaming a base cells that a sub overrides under the OLD name
+    still succeeds and renames the override along, keeping the link."""
+    m = rename_ns_model
+    A = m.new_space("A")
+    A.new_cells(name="foo", formula=lambda x: x)
+    B = m.new_space("B", bases=A)
+    B.foo.formula = lambda x: x + 50
+    assert B.foo._impl.is_defined()
+    assert B.foo(1) == 51
+
+    A.foo.rename("bar")
+
+    assert list(A._impl.cells) == ["bar"]
+    assert list(B._impl.cells) == ["bar"]
+    assert B.bar(1) == 51
+    assert B.bar._impl.is_defined()
+    assert B.bar._impl.bases[0] is A.bar._impl
+
+
+def test_rename_to_sub_ref_rejected(rename_ns_model):
+    """Non-Cells collisions in subs stay rejected by the pre-existing
+    _can_add check."""
+    m = rename_ns_model
+    A = m.new_space("A")
+    A.new_cells(name="foo", formula=lambda x: x)
+    B = m.new_space("B", bases=A)
+    B.myref = 42
+
+    with pytest.raises(ValueError, match="cannot create cells 'myref'"):
+        A.foo.rename("myref")
+
+    assert B.myref == 42
+    assert list(A._impl.cells) == ["foo"]
+
+
+def test_rename_to_same_name_rejected(rename_ns_model):
+    """Renaming to the current name fails as a user-facing ValueError,
+    not the internal rename_item RuntimeError."""
+    m = rename_ns_model
+    A = m.new_space("A")
+    A.new_cells(name="foo", formula=lambda x: x)
+
+    with pytest.raises(ValueError, match="cannot create cells 'foo'"):
+        A.foo.rename("foo")

--- a/modelx/tests/core/edit/test_transaction.py
+++ b/modelx/tests/core/edit/test_transaction.py
@@ -59,6 +59,37 @@ def test_rollback_interleaved_ops(txn):
     assert list(d) == ["a", "b", "c"]
 
 
+def test_rollback_restores_renamed_key(txn):
+    d = {"a": 1, "b": 2, "c": 3}
+    txn.rename_item(d, "b", "x")
+    assert list(d) == ["a", "x", "c"]
+    txn.rollback()
+    assert d == {"a": 1, "b": 2, "c": 3}
+    assert list(d) == ["a", "b", "c"]
+
+
+def test_rename_item_rejects_existing_key(txn):
+    """The rename journal records keys only, so an overwrite could not
+    be rolled back; rename_item must refuse before mutating."""
+    d = {"a": 1, "b": 2}
+    with pytest.raises(RuntimeError):
+        txn.rename_item(d, "a", "b")
+    assert d == {"a": 1, "b": 2}
+    txn.rollback()      # nothing was journaled
+    assert d == {"a": 1, "b": 2}
+
+
+def test_rename_item_missing_key_leaves_journal_clean(txn):
+    """A failed rename must not journal: a poisoned record would crash
+    the reverse replay and strand every earlier write."""
+    d = {"a": 1}
+    txn.set_item(d, "b", 2)
+    with pytest.raises(ValueError):
+        txn.rename_item(d, "missing", "x")
+    txn.rollback()
+    assert d == {"a": 1}
+
+
 def test_rollback_restores_attrs_and_runs_undo_callbacks(txn):
     class Obj:
         pass


### PR DESCRIPTION
Closes #260

## Problem

Renaming a base cells to a name a sub space already owns — its own defined cells, or one derived from another base — silently overwrote the sub's entry: formula and input data lost, no error, `_check_sanity()` passing. The transaction journal's rename record stores keys only, so a rollback could not have restored the overwritten member either.

`RenameCells.validate` relied on `_can_add` alone. `_can_add`'s tolerance for a colliding `CellsImpl` in a sub space is correct for `NewCells` — the sub's defined cells legitimately becomes an override — but `RenameCells.apply` rewrites every sub's cells entry in place, so the same tolerance turned into silent destruction.

## Fix

- `RenameCells.validate` now rejects the rename with a `ValueError` naming both cells when the new name exists anywhere in a sub space, after the more fundamental "is a sub Cells" check so derived-cells renames keep their original error.
- Defense in depth: `Transaction.rename_item` refuses to overwrite an existing key (RuntimeError, before mutating), and journals only after the rename succeeds so a failed rename cannot poison the reverse replay and strand earlier journaled writes.
- Legitimate paths are unchanged and now pinned by tests: `NewCells` onto a sub's defined name still creates an override, and renaming a base cells that a sub *overrides under the old name* still renames the override along, keeping the derivation link.

**User-visible behavior change:** `Cells.rename` now raises `ValueError` where it previously destroyed data silently. Renames that were already rejected (same-space members, refs, child spaces, global refs) are unaffected.

## Tests

- `test_rename.py`: rejection of sub-defined, other-base-derived, and deep-sub collisions (with message pins); override-rename control case; sub-ref and same-name rejections (pinning the pre-existing `_can_add` arm).
- `test_transaction.py`: rename rollback restores key order; `rename_item` refuses existing keys without journaling; a failed rename leaves the journal clean.

Full suite: 1167 passed, 6 skipped (Python 3.13, Windows). Flake8 reports no new findings on the touched files. Mid-edit failure paths were additionally exercised by scripted rollback probes (bit-identical container restoration, sanity checks passing, no namespace notify on failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)