### PR TITLE
FIX: Prevent Cells rename collisions in sub spaces

### DIFF
--- a/modelx/core/edit/pipeline.py
+++ b/modelx/core/edit/pipeline.py
@@ -326,6 +326,10 @@ class RenameCells(Edit):
         if not model.spmgr._can_add(self.cells.parent, self.name, CellsImpl):
             raise ValueError("cannot create cells '%s'" % self.name)
 
+        if model.spmgr._find_name_in_subs(
+                self.cells.parent, self.name, skip_self=True) is not None:
+            raise ValueError("cannot create cells '%s'" % self.name)
+
         if self.cells.bases:
             raise ValueError("'%s' is a sub Cells of '%s'" % (
                 self.cells.get_repr(fullname=True, add_params=False),

--- a/modelx/tests/core/cells/test_rename.py
+++ b/modelx/tests/core/cells/test_rename.py
@@ -117,3 +117,28 @@ def test_rename_rebinds_sub_space_namespace(rename_ns_model):
         sub.bar(3)
 
     assert sub.foo_renamed(5) == 10
+
+
+def test_rename_rejects_name_defined_in_sub_space(rename_ns_model):
+    base = rename_ns_model.new_space("Base")
+    sub = rename_ns_model.new_space("Sub", bases=base)
+    base.new_cells(name="foo", formula=lambda x: x)
+    sub.new_cells(name="bar", formula=lambda x: x + 100)
+
+    with pytest.raises(ValueError):
+        base.foo.rename("bar")
+
+    assert sub.bar(1) == 101
+
+
+def test_rename_rejects_name_derived_from_other_base(rename_ns_model):
+    left = rename_ns_model.new_space("Left")
+    right = rename_ns_model.new_space("Right")
+    left.new_cells(name="foo", formula=lambda x: x)
+    right.new_cells(name="bar", formula=lambda x: x + 100)
+    sub = rename_ns_model.new_space("Sub", bases=[left, right])
+
+    with pytest.raises(ValueError):
+        left.foo.rename("bar")
+
+    assert sub.bar(1) == 101


### PR DESCRIPTION
Closes #260

Reject a Cells rename when the destination name already belongs to a descendant space, preserving both locally defined and independently derived Cells. The two collision paths now have regression coverage that fails before this validation and passes with it.
