### PR TITLE
Fix missing format argument in warning message

### DIFF
--- a/modelx/serialize/ziputil.py
+++ b/modelx/serialize/ziputil.py
@@ -316,7 +316,8 @@ def copy_file(src: pathlib.Path, dst: pathlib.Path,
                             raise ValueError("invalid archive '%s'" % arc_dst)
             except PermissionError:
                 if i < retries - 1:
-                    warnings.warn("writing to '%s' failed, retrying...")
+                    warnings.warn(
+                        "writing to '%s' failed, retrying..." % root_dst)
                     time.sleep(1)
                     continue
                 else:


### PR DESCRIPTION
## Summary
Fixed a bug in the `copy_file` function where a warning message was missing its format argument, causing the placeholder to not be replaced with the actual value.

## Key Changes
- Added the missing `% root_dst` format argument to the warning message in `modelx/serialize/ziputil.py`
- The warning message now properly displays the destination path that failed to write, making debugging easier

## Implementation Details
The warning message "writing to '%s' failed, retrying..." had a format placeholder (`%s`) but was missing the corresponding format argument. This would have resulted in the literal string being displayed instead of the actual file path. The fix adds `% root_dst` to properly format the message with the destination path value.

https://claude.ai/code/session_01GB2ndK6NC9KL5AVsWYd1Cq