### PR TITLE
Make serializer 6/7 output deterministic (stable ids instead of id())

### DIFF
--- a/modelx/io/baseio.py
+++ b/modelx/io/baseio.py
@@ -480,7 +480,11 @@ class BaseIOSpec:
             "manager": self._manager,
             "_io": self._io
         }
-        if hasattr(self, "_is_hidden"):
+        # Omit is_hidden when False: every reader treats a missing key
+        # as False, and reloading sets _is_hidden = False on specs that
+        # never had it, so emitting False would make a save -> load ->
+        # save round trip produce different bytes.
+        if getattr(self, "_is_hidden", False):
             state["is_hidden"] = self._is_hidden
         if self._manager.serializing is True:
             return self._on_serialize(state)

--- a/modelx/serialize/custom_pickle.py
+++ b/modelx/serialize/custom_pickle.py
@@ -83,12 +83,18 @@ class ModelPickler(pickle.Pickler):
         super().__init__(file)
         self.writer = writer
 
+    def spec_id(self, obj):
+        # The id emitted for a BaseIOSpec must match a key of the
+        # iospecs dict written to iospecs.pickle, which serializer 4/5
+        # writers key by memory address.
+        return id(obj)
+
     def persistent_id(self, obj):
 
         if id(obj) in self.writer.value_id_map:
             return "DataValue", self.writer.value_id_map[id(obj)]
         elif isinstance(obj, BaseIOSpec):
-            return "BaseIOSpec", id(obj)
+            return "BaseIOSpec", self.spec_id(obj)
         elif isinstance(obj, BaseSharedIO):
             return "BaseSharedIO", obj.path.as_posix(), obj.__class__, obj.persistent_args
         elif isinstance(obj, BaseNode):
@@ -114,6 +120,18 @@ class ModelPickler(pickle.Pickler):
             return "System", None
         else:
             return None
+
+
+class DeterministicModelPickler(ModelPickler):
+    """ModelPickler for writers with an ``assign_id`` allocator (v6+).
+
+    Emits the writer-assigned process-independent id for BaseIOSpec
+    objects instead of their memory address, matching the keys of the
+    iospecs dict those writers save to iospecs.pickle.
+    """
+
+    def spec_id(self, obj):
+        return self.writer.assign_id(obj)
 
 
 class ModelUnpickler(pickle.Unpickler):

--- a/modelx/serialize/custom_pickle.py
+++ b/modelx/serialize/custom_pickle.py
@@ -89,10 +89,17 @@ class ModelPickler(pickle.Pickler):
         # writers key by memory address.
         return id(obj)
 
+    def data_value_id(self, obj):
+        # The emitted spec id if obj is an iospec-managed value, else
+        # None. Serializer 4/5 writers map values to memory-address
+        # spec ids upfront.
+        return self.writer.value_id_map.get(id(obj))
+
     def persistent_id(self, obj):
 
-        if id(obj) in self.writer.value_id_map:
-            return "DataValue", self.writer.value_id_map[id(obj)]
+        data_value_id = self.data_value_id(obj)
+        if data_value_id is not None:
+            return "DataValue", data_value_id
         elif isinstance(obj, BaseIOSpec):
             return "BaseIOSpec", self.spec_id(obj)
         elif isinstance(obj, BaseSharedIO):
@@ -125,13 +132,20 @@ class ModelPickler(pickle.Pickler):
 class DeterministicModelPickler(ModelPickler):
     """ModelPickler for writers with an ``assign_id`` allocator (v6+).
 
-    Emits the writer-assigned process-independent id for BaseIOSpec
-    objects instead of their memory address, matching the keys of the
-    iospecs dict those writers save to iospecs.pickle.
+    Emits writer-assigned process-independent ids for BaseIOSpec
+    objects and iospec-managed values instead of memory addresses,
+    matching the keys of the iospecs dict those writers save to
+    iospecs.pickle.
     """
 
     def spec_id(self, obj):
         return self.writer.assign_id(obj)
+
+    def data_value_id(self, obj):
+        spec = self.writer.iospec_by_value.get(id(obj))
+        if spec is None:
+            return None
+        return self.writer.assign_id(spec)
 
 
 class ModelUnpickler(pickle.Unpickler):

--- a/modelx/serialize/serializer_6.py
+++ b/modelx/serialize/serializer_6.py
@@ -35,7 +35,7 @@ from .deserializer import (
     get_statement_tokens, StatementTokens, SECTION_DIVIDER, SECTIONS)
 from .custom_pickle import (
     IOSpecUnpickler, ModelUnpickler,
-    IOSpecPickler, ModelPickler)
+    IOSpecPickler, DeterministicModelPickler)
 from .reader_state import SystemStateSnapshot
 
 
@@ -55,13 +55,13 @@ class TupleID(tuple):
 
         return tuple(decoded)
 
-    def serialize(self):
+    def serialize(self, assign_id):
         keys = []
         for key in self:
             if isinstance(key, str):
                 keys.append('"%s"' % key)
             elif isinstance(key, tuple):
-                keys.append(str(id(key)))
+                keys.append(str(assign_id(key)))
 
         if len(keys) == 1:
             keystr = "(%s,)" % keys[0]
@@ -70,10 +70,10 @@ class TupleID(tuple):
 
         return keystr
 
-    def pickle_args(self, argsdict):
+    def pickle_args(self, argsdict, assign_id):
         for key in self:
             if isinstance(key, tuple):
-                id_ = id(key)
+                id_ = assign_id(key)
                 if id_ not in argsdict:
                     argsdict[id_] = key
             elif isinstance(key, str):
@@ -326,9 +326,11 @@ class ModelWriter:
 
         self.system = system
         self.model = model
-        self.iospecs = {id(sp): sp for sp in self.model.iospecs}
-        self.value_id_map = {   # id(value) -> id(iospec)
-            id(sp.value): id(sp) for sp in self.model.iospecs}
+        self._assigned_ids = {}     # id(obj) -> id emitted into output files
+        self._assigned_objs = []    # keeps objs alive so memory ids stay unique
+        self.iospecs = {self.assign_id(sp): sp for sp in self.model.iospecs}
+        self.value_id_map = {   # id(value) -> assigned id of iospec
+            id(sp.value): self.assign_id(sp) for sp in self.model.iospecs}
         self.root = path
         self.temp_root = path   # Put zip in temp dir and copy later (GH82)
         self.work_dir = path    # Sub dir in temp to put IO files before archiving
@@ -338,6 +340,24 @@ class ModelWriter:
         self.input_log = []
         self.compression = compression
         self.compresslevel = compresslevel
+
+    def assign_id(self, obj):
+        """Return a process-independent id for ``obj`` to emit into output.
+
+        Sequential ints in first-encounter order replace memory addresses
+        so that saving the same model state always produces the same
+        bytes. The id is memoized per object, preserving the identity
+        deduplication that ``pickledata`` relies on, and a reference to
+        ``obj`` is kept so a recycled memory address cannot alias two
+        objects.
+        """
+        key = id(obj)
+        assigned = self._assigned_ids.get(key)
+        if assigned is None:
+            assigned = len(self._assigned_objs) + 1
+            self._assigned_ids[key] = assigned
+            self._assigned_objs.append(obj)
+        return assigned
 
     def write_model(self):
 
@@ -422,7 +442,8 @@ class ModelWriter:
         if self.pickledata:
             file = self.temp_root / "_data/data.pickle"
             ziputil.write_file_utf8(
-                lambda f: ModelPickler(f, writer=self).dump(self.pickledata),
+                lambda f: DeterministicModelPickler(
+                    f, writer=self).dump(self.pickledata),
                 file, mode="b",
                 compression=self.compression,
                 compresslevel=self.compresslevel
@@ -608,18 +629,21 @@ class SpaceEncoder(BaseEncoder):
         for cells in space.cells.values():
             for key in cells._impl.input_keys:
                 value = cells._impl.data[key]
-                keyid = id(key)
+                keyid = self.writer.assign_id(key)
                 if keyid not in self.writer.pickledata:
                     self.writer.pickledata[keyid] = key
-                valid = id(value)
+                valid = self.writer.assign_id(value)
                 if valid not in self.writer.pickledata:
                     self.writer.pickledata[valid] = value
 
                 idtuple = TupleID(abs_to_rel_tuple(
                     cells._idtuple, static_parent._idtuple))
-                idtuple.pickle_args(self.writer.pickledata)
+                idtuple.pickle_args(
+                    self.writer.pickledata, self.writer.assign_id)
                 file.write(
-                    "(%s, %s, %s)\n" % (idtuple.serialize(), keyid, valid)
+                    "(%s, %s, %s)\n" % (
+                        idtuple.serialize(self.writer.assign_id),
+                        keyid, valid)
                 )
 
                 if self.writer.log_input:
@@ -696,10 +720,10 @@ class CellsEncoder(BaseEncoder):
         for key in self.target._impl.data:
             if key in self.target._impl.input_keys:
                 value = self.target._impl.data[key]
-                keyid = id(key)
+                keyid = self.writer.assign_id(key)
                 if keyid not in self.writer.pickledata:
                     self.writer.pickledata[keyid] = key
-                valid = id(value)
+                valid = self.writer.assign_id(value)
                 if valid not in self.writer.pickledata:
                     self.writer.pickledata[valid] = value
                 cellsdata.append((keyid, valid))
@@ -743,10 +767,11 @@ class InterfaceRefEncoder(BaseEncoder):
             self.parent._idtuple
         ))
         if tuple(int(i) for i in mx.__version__.split(".")[:3]) < (0, 10):
-            return "(\"Interface\", %s)" % idtuple.serialize()
+            return "(\"Interface\", %s)" % idtuple.serialize(
+                self.writer.assign_id)
         else:
             return "(\"Interface\", %s, \"%s\")" % (
-                idtuple.serialize(),
+                idtuple.serialize(self.writer.assign_id),
                 self.target.refmode
             )
 
@@ -756,7 +781,7 @@ class InterfaceRefEncoder(BaseEncoder):
             self.target.value._idtuple,
             self.parent._idtuple
         ))
-        idtuple.pickle_args(self.writer.pickledata)
+        idtuple.pickle_args(self.writer.pickledata, self.writer.assign_id)
 
     def instruct(self):
         return Instruction(self.pickle_value)
@@ -789,12 +814,12 @@ class IOSpecEncoder(BaseEncoder):
             return False
 
     def encode(self):
-        value_id = id(self.target.value)
-        spec_id = self.writer.value_id_map[value_id]
+        value_id = self.writer.assign_id(self.target.value)
+        spec_id = self.writer.value_id_map[id(self.target.value)]
         return "(\"IOSpec\", %s, %s)" % (value_id, spec_id)
 
     def pickle_value(self):
-        key = id(self.target.value)
+        key = self.writer.assign_id(self.target.value)
 
         if key not in self.writer.pickledata:
             self.writer.pickledata[key] = self.target.value
@@ -825,12 +850,12 @@ class PickleEncoder(BaseEncoder):
 
     def pickle_value(self):
         value = self.target.value
-        key = id(value)
+        key = self.writer.assign_id(value)
         if key not in self.writer.pickledata:
             self.writer.pickledata[key] = value
 
     def encode(self):
-        return "(\"Pickle\", %s)" % id(self.target.value)
+        return "(\"Pickle\", %s)" % self.writer.assign_id(self.target.value)
 
     def instruct(self):
         return Instruction(self.pickle_value)

--- a/modelx/serialize/serializer_6.py
+++ b/modelx/serialize/serializer_6.py
@@ -98,7 +98,9 @@ def _sorted_itemspaces(itemspaces):
 
 
 def _value_order_key(value):
-    if isinstance(value, Interface):
+    # A deleted object's Interface raises on any attribute access, so
+    # it must fall through to the type-only key below.
+    if isinstance(value, Interface) and value._is_valid():
         return "i:%s" % ",".join(
             part if isinstance(part, str) else _value_order_key(part)
             for part in value._idtuple)
@@ -422,6 +424,7 @@ class ModelWriter:
 
             self._write_recursive(encoder)
             self.write_pickledata()
+            self._reorder_io_specs()
             self.system.iomanager.write_ios(self.model, root=self.work_dir)
 
             if self.log_input:
@@ -465,6 +468,24 @@ class ModelWriter:
             self._write_recursive(e)
 
         encoder.instruct().execute()
+
+    def _reorder_io_specs(self):
+        """Put each shared IO's spec registry in assigned-id order.
+
+        Multi-spec IO files are written by iterating the registry
+        (e.g. one Excel sheet per spec), and a reload rebuilds the
+        registry in iospecs.pickle order, which is assigned-id order.
+        Left in the session's registration order, the first resave
+        after a reload would permute such files (GH: sheet order).
+        Runs after write_pickledata, which assigns every spec its id.
+        """
+        ios = []
+        for sp in self.model.iospecs:
+            if sp.io not in ios:
+                ios.append(sp.io)
+        for io_ in ios:
+            specs = sorted(io_._specs.values(), key=self.assign_id)
+            io_._specs = {id(sp): sp for sp in specs}
 
     def write_pickledata(self):
         if self.model.iospecs:

--- a/modelx/serialize/serializer_6.py
+++ b/modelx/serialize/serializer_6.py
@@ -82,6 +82,37 @@ class TupleID(tuple):
                 raise ValueError("unknown tuple id")
 
 
+def _sorted_itemspaces(itemspaces):
+    """Order ItemSpaces by their item arguments, not by creation order.
+
+    Creation order is not preserved by a save -> load round trip
+    (ItemSpaces referenced by Interface refs are re-created before
+    those replayed from _dynamic_inputs), so emitting dynamic inputs
+    in creation order would make a no-op resave produce different
+    bytes. The key is derived from the argument values alone; the
+    auto-assigned name only breaks ties between argument types the
+    key function cannot represent process-independently.
+    """
+    return sorted(
+        itemspaces, key=lambda s: (_value_order_key(s.argvalues), s.name))
+
+
+def _value_order_key(value):
+    if isinstance(value, Interface):
+        return "i:%s" % ",".join(
+            part if isinstance(part, str) else _value_order_key(part)
+            for part in value._idtuple)
+    elif isinstance(value, tuple):
+        return "t:(%s)" % ",".join(_value_order_key(v) for v in value)
+    elif isinstance(value, (bool, int, float, str, bytes, type(None))):
+        return "%s:%r" % (type(value).__name__, value)
+    else:
+        # repr may embed a memory address, so fall back to the type
+        # alone and let the caller's tiebreaker decide.
+        return "o:%s.%s" % (
+            type(value).__module__, type(value).__qualname__)
+
+
 class PriorityID(enum.IntEnum):
     NORMAL = 1
     AT_PARSE = 2
@@ -328,9 +359,12 @@ class ModelWriter:
         self.model = model
         self._assigned_ids = {}     # id(obj) -> id emitted into output files
         self._assigned_objs = []    # keeps objs alive so memory ids stay unique
-        self.iospecs = {self.assign_id(sp): sp for sp in self.model.iospecs}
-        self.value_id_map = {   # id(value) -> assigned id of iospec
-            id(sp.value): self.assign_id(sp) for sp in self.model.iospecs}
+        # Spec ids are assigned lazily at first traversal encounter, not
+        # here: model.iospecs enumerates specs in ref-registration order,
+        # which a save -> load round trip does not preserve, while the
+        # traversal order is derived from the model tree alone.
+        self.iospec_by_value = {    # id(value) -> iospec managing it
+            id(sp.value): sp for sp in self.model.iospecs}
         self.root = path
         self.temp_root = path   # Put zip in temp dir and copy later (GH82)
         self.work_dir = path    # Sub dir in temp to put IO files before archiving
@@ -344,12 +378,14 @@ class ModelWriter:
     def assign_id(self, obj):
         """Return a process-independent id for ``obj`` to emit into output.
 
-        Sequential ints in first-encounter order replace memory addresses
-        so that saving the same model state always produces the same
-        bytes. The id is memoized per object, preserving the identity
-        deduplication that ``pickledata`` relies on, and a reference to
-        ``obj`` is kept so a recycled memory address cannot alias two
-        objects.
+        Sequential ints in first-encounter order replace memory
+        addresses, so the ids emitted for the same model state do not
+        vary from one process run to the next. (Ids are only one source
+        of output bytes: values whose own pickle is hash-order
+        dependent, such as sets of strings, can still vary.) The id is
+        memoized per object, preserving the identity deduplication that
+        ``pickledata`` relies on, and a reference to ``obj`` is kept so
+        a recycled memory address cannot alias two objects.
         """
         key = id(obj)
         assigned = self._assigned_ids.get(key)
@@ -432,9 +468,15 @@ class ModelWriter:
 
     def write_pickledata(self):
         if self.model.iospecs:
+            # Assign ids to any spec the traversal did not reach, then
+            # key the dict in id order: model.iospecs order is
+            # ref-registration order, which a save -> load round trip
+            # does not preserve.
+            iospecs = dict(sorted(
+                (self.assign_id(sp), sp) for sp in self.model.iospecs))
             file = self.temp_root / "_data/iospecs.pickle"
             ziputil.write_file_utf8(
-                lambda f: IOSpecPickler(f).dump(self.iospecs),
+                lambda f: IOSpecPickler(f).dump(iospecs),
                 file, mode="b",
                 compression=self.compression,
                 compresslevel=self.compresslevel
@@ -613,21 +655,27 @@ class SpaceEncoder(BaseEncoder):
     def pickle_dynamic_inputs(self):
 
         datafile = self.datapath / "_dynamic_inputs"
+        lines = []
+        for s in _sorted_itemspaces(self.space._named_itemspaces.values()):
+            self._pickle_dynamic_space(lines, s, self.space)
 
-        if self.space._named_itemspaces:
+        # No file when there is nothing to record: ItemSpaces without
+        # inputs are not re-created on load, so an empty file written
+        # for them would disappear from the next save.
+        if lines:
+            ziputil.write_str_utf8("".join(lines), datafile,
+                                   compression=self.writer.compression,
+                                   compresslevel=self.writer.compresslevel)
 
-            def callback(f):
-                for s in self.space._named_itemspaces.values():
-                    self._pickle_dynamic_space(f, s, self.space)
-
-            ziputil.write_file_utf8(callback, datafile, "t",
-                                    compression=self.writer.compression,
-                                    compresslevel=self.writer.compresslevel)
-
-    def _pickle_dynamic_space(self, file, space, static_parent):
+    def _pickle_dynamic_space(self, lines, space, static_parent):
 
         for cells in space.cells.values():
-            for key in cells._impl.input_keys:
+            # Iterate the data dict, whose insertion order the reader
+            # reproduces, rather than the input_keys set, whose
+            # iteration order is hash-seed dependent for str keys.
+            for key in cells._impl.data:
+                if key not in cells._impl.input_keys:
+                    continue
                 value = cells._impl.data[key]
                 keyid = self.writer.assign_id(key)
                 if keyid not in self.writer.pickledata:
@@ -640,7 +688,7 @@ class SpaceEncoder(BaseEncoder):
                     cells._idtuple, static_parent._idtuple))
                 idtuple.pickle_args(
                     self.writer.pickledata, self.writer.assign_id)
-                file.write(
+                lines.append(
                     "(%s, %s, %s)\n" % (
                         idtuple.serialize(self.writer.assign_id),
                         keyid, valid)
@@ -651,10 +699,10 @@ class SpaceEncoder(BaseEncoder):
                         output_input(cells, key))
 
         for subspace in space.named_spaces.values():
-            self._pickle_dynamic_space(file, subspace, static_parent)
+            self._pickle_dynamic_space(lines, subspace, static_parent)
 
-        for subspace in space._named_itemspaces.values():
-            self._pickle_dynamic_space(file, subspace, static_parent)
+        for subspace in _sorted_itemspaces(space._named_itemspaces.values()):
+            self._pickle_dynamic_space(lines, subspace, static_parent)
 
 
 class RefViewEncoder(BaseEncoder):
@@ -809,14 +857,14 @@ class IOSpecEncoder(BaseEncoder):
     def condition(cls, ref, writer):
 
         if not isinstance(ref, Interface): # Avoid null object
-            return id(ref.value) in writer.value_id_map
+            return id(ref.value) in writer.iospec_by_value
         else:
             return False
 
     def encode(self):
         value_id = self.writer.assign_id(self.target.value)
-        spec_id = self.writer.value_id_map[id(self.target.value)]
-        return "(\"IOSpec\", %s, %s)" % (value_id, spec_id)
+        spec = self.writer.iospec_by_value[id(self.target.value)]
+        return "(\"IOSpec\", %s, %s)" % (value_id, self.writer.assign_id(spec))
 
     def pickle_value(self):
         key = self.writer.assign_id(self.target.value)
@@ -833,7 +881,7 @@ class ModuleEncoder(BaseEncoder):
     @classmethod
     def condition(cls, ref, writer):
         value = ref.value
-        if id(value) in writer.value_id_map:   # Use PickleEncoder
+        if id(value) in writer.iospec_by_value:   # Use PickleEncoder
             return False
         else:
             return isinstance(value, types.ModuleType)

--- a/modelx/serialize/serializer_6.py
+++ b/modelx/serialize/serializer_6.py
@@ -478,12 +478,21 @@ class ModelWriter:
         Left in the session's registration order, the first resave
         after a reload would permute such files (GH: sheet order).
         Runs after write_pickledata, which assigns every spec its id.
+
+        An IO holding specs of other live models too (an absolute-path
+        file with group None) is left alone: no single model's ids
+        define an order for it, and reordering it here would permute
+        the shared file on every alternate-model save.
         """
+        model_spec_ids = set(id(sp) for sp in self.model.iospecs)
         ios = []
         for sp in self.model.iospecs:
             if sp.io not in ios:
                 ios.append(sp.io)
         for io_ in ios:
+            if any(id(sp) not in model_spec_ids
+                   for sp in io_._specs.values()):
+                continue
             specs = sorted(io_._specs.values(), key=self.assign_id)
             io_._specs = {id(sp): sp for sp in specs}
 

--- a/modelx/serialize/serializer_7.py
+++ b/modelx/serialize/serializer_7.py
@@ -128,6 +128,7 @@ class ModelWriter(serializer_6.ModelWriter):
             self._write_recursive(encoder)
             self._write_macros()
             self.write_pickledata()
+            self._reorder_io_specs()
             self.system.iomanager.write_ios(self.model, root=self.work_dir)
 
             if self.log_input:

--- a/modelx/tests/serialize/test_deterministic_output.py
+++ b/modelx/tests/serialize/test_deterministic_output.py
@@ -1,0 +1,114 @@
+"""Round-trip determinism of the serializer 6/7 writers.
+
+A no-op save -> load -> save round trip must produce byte-identical
+output trees: the writers emit sequential writer-assigned ids instead
+of memory addresses (``id()``), so the bytes cannot vary from one
+process run to the next.
+"""
+
+import zipfile
+
+import pytest
+
+import modelx as mx
+
+
+def t_arg(t):
+    pass
+
+
+def _build_model(name):
+    """Build a model exercising every id-emitting site of the writer.
+
+    Covers cells input values (one value shared between two cells and
+    a dynamic input, to test identity dedup), a Pickle-encoded ref, an
+    IOSpec ref (new_pandas), an Interface ref to an ItemSpace (tuple
+    args), and ItemSpace dynamic inputs.
+    """
+    pd = pytest.importorskip("pandas")
+
+    m = mx.new_model(name)
+    s = m.new_space("Space1", formula=t_arg)
+
+    @mx.defcells
+    def foo(x):
+        return x
+
+    @mx.defcells
+    def bar(x):
+        return x
+
+    shared = [1, 2, 3]
+    s.foo[1] = shared
+    s.bar[1] = shared
+    s.foo[2] = 100
+
+    m.pickle_ref = {"key": (1, 2)}
+
+    df = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
+    s.new_pandas(name="pdref", path="files/data.csv",
+                 data=df, file_type="csv")
+
+    # Interface ref to an ItemSpace: its idtuple contains an args tuple.
+    # Created before the dynamic inputs below so that the ItemSpace
+    # creation order matches the reader's restore order (refs are set
+    # before dynamic inputs).
+    m.new_space("SpaceB", refs={"RefSpaceA": m.Space1(0)})
+
+    s[1].foo[3] = [7, 8]
+    s[1].bar[3] = shared
+
+    return m
+
+
+def _assert_identical_trees(path1, path2):
+    files1 = sorted(p.relative_to(path1) for p in path1.rglob("*")
+                    if p.is_file())
+    files2 = sorted(p.relative_to(path2) for p in path2.rglob("*")
+                    if p.is_file())
+    assert files1 == files2
+    for rel in files1:
+        assert (path1 / rel).read_bytes() == (path2 / rel).read_bytes(), \
+            "file differs between saves: %s" % rel
+
+
+def _assert_identical_zips(path1, path2):
+    # Compare entry bytes, not archive bytes: zip headers embed
+    # timestamps that legitimately differ between the two saves.
+    with zipfile.ZipFile(path1) as z1, zipfile.ZipFile(path2) as z2:
+        names1 = sorted(z1.namelist())
+        names2 = sorted(z2.namelist())
+        assert names1 == names2
+        for name in names1:
+            assert z1.read(name) == z2.read(name), \
+                "zip entry differs between saves: %s" % name
+
+
+@pytest.mark.parametrize("version", [6, 7])
+@pytest.mark.parametrize("write_method", ["write_model", "zip_model"])
+def test_roundtrip_determinism(
+        tmp_path, write_method, version, close_new_models):
+
+    m = _build_model("DetModel%s" % version)
+    path1 = tmp_path / "save1"
+    getattr(mx, write_method)(m, path1, version=version)
+    m.close()
+
+    m2 = mx.read_model(path1)
+
+    # Sanity: the model and the identity dedup survived the round trip.
+    assert m2.Space1.foo[1] == [1, 2, 3]
+    assert m2.Space1.foo[1] is m2.Space1.bar[1]
+    assert m2.Space1[1].bar[3] is m2.Space1.foo[1]
+    assert m2.Space1[1].foo[3] == [7, 8]
+    assert m2.pickle_ref == {"key": (1, 2)}
+    assert m2.SpaceB.RefSpaceA is m2.Space1(0)
+
+    path2 = tmp_path / "save2"
+    getattr(mx, write_method)(m2, path2, version=version)
+    m2.close()
+
+    if write_method == "zip_model":
+        _assert_identical_zips(path1, path2)
+    else:
+        _assert_identical_trees(path1, path2)

--- a/modelx/tests/serialize/test_deterministic_output.py
+++ b/modelx/tests/serialize/test_deterministic_output.py
@@ -2,10 +2,16 @@
 
 A no-op save -> load -> save round trip must produce byte-identical
 output trees: the writers emit sequential writer-assigned ids instead
-of memory addresses (``id()``), so the bytes cannot vary from one
-process run to the next.
+of memory addresses (``id()``), assign them in orders derived from the
+model state rather than from session history, and avoid iterating sets
+whose order depends on the process hash seed. (Values whose own pickle
+is hash-order dependent, such as sets of strings, are outside the
+writers' control and can still vary across processes.)
 """
 
+import os
+import subprocess
+import sys
 import zipfile
 
 import pytest
@@ -21,9 +27,18 @@ def _build_model(name):
     """Build a model exercising every id-emitting site of the writer.
 
     Covers cells input values (one value shared between two cells and
-    a dynamic input, to test identity dedup), a Pickle-encoded ref, an
-    IOSpec ref (new_pandas), an Interface ref to an ItemSpace (tuple
-    args), and ItemSpace dynamic inputs.
+    a dynamic input, to test identity dedup), a Pickle-encoded ref,
+    IOSpec refs (new_pandas), an Interface ref to an ItemSpace (tuple
+    args), and ItemSpace dynamic inputs, including a str cells key.
+
+    The creation orders are deliberately adversarial: the space-level
+    iospec is created before the model-level one, although the writer
+    traverses the model's refs first, and the dynamic inputs are set
+    before the Interface ref although the reader re-creates the ref'd
+    ItemSpace first. Reloading therefore reorders both
+    ``model.iospecs`` and ``_named_itemspaces`` relative to this
+    build, and only state-derived (not history-derived) id assignment
+    keeps the resave byte-identical.
     """
     pd = pytest.importorskip("pandas")
 
@@ -48,15 +63,15 @@ def _build_model(name):
     df = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
     s.new_pandas(name="pdref", path="files/data.csv",
                  data=df, file_type="csv")
-
-    # Interface ref to an ItemSpace: its idtuple contains an args tuple.
-    # Created before the dynamic inputs below so that the ItemSpace
-    # creation order matches the reader's restore order (refs are set
-    # before dynamic inputs).
-    m.new_space("SpaceB", refs={"RefSpaceA": m.Space1(0)})
+    m.new_pandas(name="pdref_model", path="files/data_model.csv",
+                 data=df * 2, file_type="csv")
 
     s[1].foo[3] = [7, 8]
     s[1].bar[3] = shared
+    s[1].foo["alpha"] = 9
+    s[2].foo["bravo"] = 10
+
+    m.new_space("SpaceB", refs={"RefSpaceA": m.Space1(0)})
 
     return m
 
@@ -84,6 +99,18 @@ def _assert_identical_zips(path1, path2):
                 "zip entry differs between saves: %s" % name
 
 
+def _assert_loaded_model(m2):
+    """The model and the identity dedup survived the round trip."""
+    assert m2.Space1.foo[1] == [1, 2, 3]
+    assert m2.Space1.foo[1] is m2.Space1.bar[1]
+    assert m2.Space1[1].bar[3] is m2.Space1.foo[1]
+    assert m2.Space1[1].foo[3] == [7, 8]
+    assert m2.Space1[1].foo["alpha"] == 9
+    assert m2.Space1[2].foo["bravo"] == 10
+    assert m2.pickle_ref == {"key": (1, 2)}
+    assert m2.SpaceB.RefSpaceA is m2.Space1(0)
+
+
 @pytest.mark.parametrize("version", [6, 7])
 @pytest.mark.parametrize("write_method", ["write_model", "zip_model"])
 def test_roundtrip_determinism(
@@ -95,14 +122,7 @@ def test_roundtrip_determinism(
     m.close()
 
     m2 = mx.read_model(path1)
-
-    # Sanity: the model and the identity dedup survived the round trip.
-    assert m2.Space1.foo[1] == [1, 2, 3]
-    assert m2.Space1.foo[1] is m2.Space1.bar[1]
-    assert m2.Space1[1].bar[3] is m2.Space1.foo[1]
-    assert m2.Space1[1].foo[3] == [7, 8]
-    assert m2.pickle_ref == {"key": (1, 2)}
-    assert m2.SpaceB.RefSpaceA is m2.Space1(0)
+    _assert_loaded_model(m2)
 
     path2 = tmp_path / "save2"
     getattr(mx, write_method)(m2, path2, version=version)
@@ -112,3 +132,37 @@ def test_roundtrip_determinism(
         _assert_identical_zips(path1, path2)
     else:
         _assert_identical_trees(path1, path2)
+
+
+_RESAVE_SCRIPT = """\
+import sys
+sys.path.insert(0, sys.argv[3])
+import modelx as mx
+m = mx.read_model(sys.argv[1])
+mx.write_model(m, sys.argv[2])
+"""
+
+
+def test_cross_process_determinism(tmp_path, close_new_models):
+    """Resaving in fresh processes with different hash seeds must
+    reproduce the original save byte for byte."""
+    m = _build_model("XProcDetModel")
+    path1 = tmp_path / "save1"
+    mx.write_model(m, path1)
+    m.close()
+
+    script = tmp_path / "resave.py"
+    script.write_text(_RESAVE_SCRIPT)
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(mx.__file__)))
+
+    resaved = []
+    for seed in ("1", "2"):
+        out = tmp_path / ("resave_seed" + seed)
+        env = dict(os.environ, PYTHONHASHSEED=seed)
+        subprocess.run(
+            [sys.executable, str(script), str(path1), str(out), repo_root],
+            check=True, env=env, capture_output=True)
+        resaved.append(out)
+
+    _assert_identical_trees(path1, resaved[0])
+    _assert_identical_trees(resaved[0], resaved[1])

--- a/modelx/tests/serialize/test_deterministic_output.py
+++ b/modelx/tests/serialize/test_deterministic_output.py
@@ -136,11 +136,12 @@ def test_roundtrip_determinism(
         _assert_identical_trees(path1, path2)
 
 
-def test_deleted_itemspace_arg(tmp_path, close_new_models):
+@pytest.mark.parametrize("version", [6, 7])
+def test_deleted_itemspace_arg(tmp_path, version, close_new_models):
     """An ItemSpace whose argument was deleted must still save (the
     dead Interface has no content-derived sort key) and round-trip
     byte-identically."""
-    m = mx.new_model("DetDeletedArg")
+    m = mx.new_model("DetDeletedArg%s" % version)
     s = m.new_space("Space1", formula=t_arg)
     s.new_cells(name="foo", formula=lambda x: x)
     sc = m.new_space("SpaceC")
@@ -149,25 +150,26 @@ def test_deleted_itemspace_arg(tmp_path, close_new_models):
     del m.SpaceC
 
     path1 = tmp_path / "save1"
-    mx.write_model(m, path1)
+    mx.write_model(m, path1, version=version)
     m.close()
 
     m2 = mx.read_model(path1)
     path2 = tmp_path / "save2"
-    mx.write_model(m2, path2)
+    mx.write_model(m2, path2, version=version)
     m2.close()
 
     _assert_identical_trees(path1, path2)
 
 
-def test_shared_excel_sheet_order(tmp_path, close_new_models):
+@pytest.mark.parametrize("version", [6, 7])
+def test_shared_excel_sheet_order(tmp_path, version, close_new_models):
     """Two specs sharing one Excel book, created in an order adversarial
     to the writer traversal: the book must not permute its sheets on a
     no-op round trip."""
     pd = pytest.importorskip("pandas")
     openpyxl = pytest.importorskip("openpyxl")
 
-    m = mx.new_model("DetSharedExcel")
+    m = mx.new_model("DetSharedExcel%s" % version)
     s1 = m.new_space("Space1")
     s2 = m.new_space("Space2")
     df = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
@@ -177,12 +179,12 @@ def test_shared_excel_sheet_order(tmp_path, close_new_models):
                   data=df * 2, file_type="excel", sheet="SheetA")
 
     path1 = tmp_path / "save1"
-    mx.write_model(m, path1)
+    mx.write_model(m, path1, version=version)
     m.close()
 
     m2 = mx.read_model(path1)
     path2 = tmp_path / "save2"
-    mx.write_model(m2, path2)
+    mx.write_model(m2, path2, version=version)
     m2.close()
 
     # xlsx files are zip archives embedding entry timestamps and a

--- a/modelx/tests/serialize/test_deterministic_output.py
+++ b/modelx/tests/serialize/test_deterministic_output.py
@@ -76,13 +76,15 @@ def _build_model(name):
     return m
 
 
-def _assert_identical_trees(path1, path2):
+def _assert_identical_trees(path1, path2, exclude=()):
     files1 = sorted(p.relative_to(path1) for p in path1.rglob("*")
                     if p.is_file())
     files2 = sorted(p.relative_to(path2) for p in path2.rglob("*")
                     if p.is_file())
     assert files1 == files2
     for rel in files1:
+        if rel.as_posix() in exclude:
+            continue
         assert (path1 / rel).read_bytes() == (path2 / rel).read_bytes(), \
             "file differs between saves: %s" % rel
 
@@ -132,6 +134,66 @@ def test_roundtrip_determinism(
         _assert_identical_zips(path1, path2)
     else:
         _assert_identical_trees(path1, path2)
+
+
+def test_deleted_itemspace_arg(tmp_path, close_new_models):
+    """An ItemSpace whose argument was deleted must still save (the
+    dead Interface has no content-derived sort key) and round-trip
+    byte-identically."""
+    m = mx.new_model("DetDeletedArg")
+    s = m.new_space("Space1", formula=t_arg)
+    s.new_cells(name="foo", formula=lambda x: x)
+    sc = m.new_space("SpaceC")
+    s[sc].foo[1] = 11
+    s[0].foo[1] = 12
+    del m.SpaceC
+
+    path1 = tmp_path / "save1"
+    mx.write_model(m, path1)
+    m.close()
+
+    m2 = mx.read_model(path1)
+    path2 = tmp_path / "save2"
+    mx.write_model(m2, path2)
+    m2.close()
+
+    _assert_identical_trees(path1, path2)
+
+
+def test_shared_excel_sheet_order(tmp_path, close_new_models):
+    """Two specs sharing one Excel book, created in an order adversarial
+    to the writer traversal: the book must not permute its sheets on a
+    no-op round trip."""
+    pd = pytest.importorskip("pandas")
+    openpyxl = pytest.importorskip("openpyxl")
+
+    m = mx.new_model("DetSharedExcel")
+    s1 = m.new_space("Space1")
+    s2 = m.new_space("Space2")
+    df = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
+    s2.new_pandas(name="pdB", path="files/book.xlsx",
+                  data=df, file_type="excel", sheet="SheetB")
+    s1.new_pandas(name="pdA", path="files/book.xlsx",
+                  data=df * 2, file_type="excel", sheet="SheetA")
+
+    path1 = tmp_path / "save1"
+    mx.write_model(m, path1)
+    m.close()
+
+    m2 = mx.read_model(path1)
+    path2 = tmp_path / "save2"
+    mx.write_model(m2, path2)
+    m2.close()
+
+    # xlsx files are zip archives embedding entry timestamps and a
+    # docProps creation time, so the workbook cannot be compared byte
+    # for byte; the defect guarded against here is its sheets being
+    # permuted by the round trip.
+    book = "files/book.xlsx"
+    _assert_identical_trees(path1, path2, exclude={book})
+    sheets1 = openpyxl.load_workbook(path1 / book).sheetnames
+    sheets2 = openpyxl.load_workbook(path2 / book).sheetnames
+    assert sheets1 == sheets2
 
 
 _RESAVE_SCRIPT = """\


### PR DESCRIPTION
## What

A no-op `write_model` -> `read_model` -> `write_model` round trip now produces byte-identical output trees for serializer 6 and 7, in directory and zip form, across processes and `PYTHONHASHSEED`s. Previously every save was dirty in git because the writers keyed pickled objects by CPython memory addresses (`id()`).

**No format change, no version bump.** The reader treats all emitted integers as opaque lookup tokens, so files written by this code load on older modelx releases, and the reader is untouched.

## How

`ModelWriter.assign_id` (serializer_6) memoizes `{id(obj): n}` per write and hands out sequential ints in first-encounter order, keeping a reference to each object so a recycled address cannot alias two objects. Identity dedup of shared values is preserved: one pickled copy, one id, referenced from every site.

Every emission site now goes through it:

- `_data/<cells>` files: `(keyid, valid)` pairs (`CellsEncoder.pickle_value`)
- `_data/_dynamic_inputs`: idtuple/key/value ids (`TupleID.serialize` / `pickle_args` now take the allocator)
- ref literals in source files: `("IOSpec", value_id, spec_id)`, `("Pickle", id)`, `("Interface", (...))`
- `_data/iospecs.pickle`: dict keys, assigned lazily in traversal order and dumped in sorted-id order
- `_data/data.pickle`: `("DataValue", spec_id)` / `("BaseIOSpec", spec_id)` persistent ids via new `spec_id` / `data_value_id` hooks on `ModelPickler`; the v6+-only `DeterministicModelPickler` overrides them while the v4/v5 writers keep byte-identical memory-id behavior

Beyond the ids themselves, emission *order* is now derived from model state, not session history (a reload does not preserve creation order):

- iospec ids: traversal-encounter order instead of ref-registration order
- dynamic inputs: iterate the insertion-ordered `data` dict instead of the `input_keys` set (set order is hash-seed dependent for str keys)
- ItemSpaces: emitted in a canonical order derived from their args (`_value_order_key`; name tiebreak for types with no process-independent key, incl. deleted-object args)
- shared multi-spec IO files (one Excel sheet per spec): each model-owned IO's registry is put in assigned-id order before `write_ios`, matching what a reload rebuilds; absolute-path IOs shared with other live models are left alone
- an empty `_dynamic_inputs` file is no longer written (ItemSpaces without inputs do not survive a reload; every reader guards the file with an existence check)
- `BaseIOSpec.__getstate__` omits `is_hidden` when False: reloading stamps `_is_hidden = False` on specs that never had it, so emitting False made every resave differ; a missing key already means False on every reader path back to v0.13

## Reviewer notes

- **v5 writer byte change (deliberate, disclosed):** the `is_hidden` omission also reaches v5's `iospecs.pickle` (shared `__getstate__`). Semantically neutral - verified loadable by releases back to v0.18 - and v4/v5 writers are already deprecated and broken end-to-end on the current core for cells-bearing models. Gating it on writer version would need global plumbing for a deprecated writer; happy to add if strict v5 byte-invariance matters.
- **Known limitations (outside the id layer):** values whose own pickle is hash-order dependent (e.g. sets of strings) can still vary across processes; xlsx IO files embed zip-entry/docProps timestamps so workbook bytes are inherently unstable (the test asserts sheet layout instead).
- One-time migration diff: the first resave of an existing model renumbers ids and may reorder dynamic-input lines/Excel sheets; output is stable from then on.
- Verified against `devnotes/DependentPackages.md`: spymx-kernels / modelx-cython depend on v6 *read* support, `_get_attrdict`, and runtime pickling - none on emitted ids being addresses.
- The change was stress-tested by three adversarial multi-agent review rounds; every confirmed finding is either fixed in these commits or listed above.

## Tests

`modelx/tests/serialize/test_deterministic_output.py` (9 tests): round-trip byte-compare over v6/v7 x dir/zip with build order adversarial to the reader's restore order, shared-value dedup asserted across cells and dynamic inputs, deleted-ItemSpace-arg and shared-Excel-sheet-order regressions (v6+v7), and a cross-process resave under two different `PYTHONHASHSEED`s. Each test fails on the code it guards against. Full suite: 1176 passed, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)