### PR TITLE
BUG: Fix name qualification for inlined comprehensions in the exporter

### DIFF
--- a/doc/source/releases/relnotes_v0_33_0.rst
+++ b/doc/source/releases/relnotes_v0_33_0.rst
@@ -2,7 +2,7 @@
 modelx v0.33.0 (not yet released)
 ====================================
 
-This release introduces the following bug fix.
+This release introduces the following bug fixes.
 
 To update modelx to the latest version, use the following command::
 
@@ -18,28 +18,19 @@ Bug Fixes
 
 * On Python 3.12 and later,
   :meth:`Model.export<modelx.core.model.Model.export>` and
-  :func:`~modelx.export_model` no longer generate wrong code for a name
-  inside a list, dict or set comprehension when the same formula contains a
-  generator expression, a lambda or a nested ``def`` ahead of the
-  comprehension.
+  :func:`~modelx.export_model` no longer drop the ``self.`` prefix from a
+  Cells or a Reference used inside a list, dict or set comprehension when
+  the same formula contains a generator expression, a lambda or a nested
+  ``def`` ahead of the comprehension. The exported formula raised
+  ``NameError`` the first time it was called. Since Python 3.12 such
+  comprehensions no longer produce a symbol table of their own, and the
+  exporter located the symbol table of the enclosing scope by position
+  rather than lexically.
 
-  Since Python 3.12, such comprehensions are compiled into the enclosing
-  function instead of into a nested one, and no longer produce a symbol
-  table of their own. The exporter located the symbol table of the enclosing
-  scope by position rather than lexically, and generator expressions,
-  lambdas and nested ``def``\ s do still produce symbol tables of their own,
-  so a comprehension that followed one of them was resolved against that
-  scope instead of against the formula.
-
-  Two kinds of wrong code could result. A reference to a Cells or a
-  Reference could lose the ``self.`` prefix it needs, in which case the
-  exported formula raised ``NameError`` the first time it was called.
-  Conversely, a comprehension's own loop variable could gain a ``self.``
-  prefix it must not have, when it happened to share its name with a Cells
-  or a Reference. ``for self.x in ...`` is valid Python, so in that case the
+* :meth:`Model.export<modelx.core.model.Model.export>` and
+  :func:`~modelx.export_model` no longer prefix the loop variable of a list,
+  dict or set comprehension with ``self.`` when it shares its name with a
+  Cells or a Reference. ``for self.x in ...`` is valid Python, so the
   exported model imported and ran, but silently rebound the member on the
-  Space object, and later calls to that member failed with errors pointing
-  nowhere near the formula that broke it.
-
-  Python 3.11 and earlier are not affected, because comprehensions produce
-  symbol tables of their own there.
+  Space object, and every later use of that member failed with an error
+  pointing nowhere near the formula that broke it.

--- a/doc/source/releases/relnotes_v0_33_0.rst
+++ b/doc/source/releases/relnotes_v0_33_0.rst
@@ -1,0 +1,45 @@
+====================================
+modelx v0.33.0 (not yet released)
+====================================
+
+This release introduces the following bug fix.
+
+To update modelx to the latest version, use the following command::
+
+    >>> pip install modelx --upgrade
+
+Anaconda users should use the ``conda`` command instead::
+
+    >>> conda update modelx
+
+
+Bug Fixes
+============
+
+* On Python 3.12 and later,
+  :meth:`Model.export<modelx.core.model.Model.export>` and
+  :func:`~modelx.export_model` no longer generate wrong code for a name
+  inside a list, dict or set comprehension when the same formula contains a
+  generator expression, a lambda or a nested ``def`` ahead of the
+  comprehension.
+
+  Since Python 3.12, such comprehensions are compiled into the enclosing
+  function instead of into a nested one, and no longer produce a symbol
+  table of their own. The exporter located the symbol table of the enclosing
+  scope by position rather than lexically, and generator expressions,
+  lambdas and nested ``def``\ s do still produce symbol tables of their own,
+  so a comprehension that followed one of them was resolved against that
+  scope instead of against the formula.
+
+  Two kinds of wrong code could result. A reference to a Cells or a
+  Reference could lose the ``self.`` prefix it needs, in which case the
+  exported formula raised ``NameError`` the first time it was called.
+  Conversely, a comprehension's own loop variable could gain a ``self.``
+  prefix it must not have, when it happened to share its name with a Cells
+  or a Reference. ``for self.x in ...`` is valid Python, so in that case the
+  exported model imported and ran, but silently rebound the member on the
+  Space object, and later calls to that member failed with errors pointing
+  nowhere near the formula that broke it.
+
+  Python 3.11 and earlier are not affected, because comprehensions produce
+  symbol tables of their own there.

--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -37,6 +37,7 @@ Release Notes - modelx
 .. toctree::
    :maxdepth: 1
 
+   releases/relnotes_v0_33_0
    releases/relnotes_v0_32_0
    releases/relnotes_v0_31_1
    releases/relnotes_v0_31_0

--- a/modelx/export/transformer.py
+++ b/modelx/export/transformer.py
@@ -24,7 +24,8 @@ import libcst
 import libcst as cst
 from libcst import FunctionDef, Module
 from libcst.metadata import (
-    GlobalScope, ClassScope, FunctionScope, ComprehensionScope, ParentNodeProvider)
+    Scope, GlobalScope, ClassScope, FunctionScope, ComprehensionScope,
+    ParentNodeProvider)
 import libcst.matchers as m
 
 
@@ -175,8 +176,28 @@ class FormulaTransformer(m.MatcherDecoratableTransformer):
         self.func_attrs = {}
         self.transformed = self.wrapper.visit(self)
 
-    def enclosing_symbols(self, scope):
-        """The name-to-symbol map of the nearest scope that owns a symtable.
+    def comprehension_binds(self, scope: Scope, name: str):
+        """Return whether ``name`` is bound by ``scope`` or by a comprehension enclosing it.
+
+        Under PEP 709 the target of an inlined comprehension becomes a symbol of the
+        enclosing scope's symtable, where it is reported as a global whenever the same
+        name is also read as a global elsewhere in that scope, or whenever the
+        comprehension sits in a default value, an annotation or a decorator, which
+        are evaluated in the scope enclosing the def. Qualifying it then yields
+        ``for self.x in ...``, which is valid Python and silently rebinds the member
+        on the Space object. libCST records the binding in the comprehension's own
+        scope, where it is unambiguous. The first iterable is not part of it: libCST
+        records it in the enclosing scope, as Python evaluates it there.
+        """
+        while isinstance(scope, ComprehensionScope):
+            if name in scope.assignments:
+                return True
+            scope = scope.parent
+
+        return False
+
+    def enclosing_symbols(self, scope: Scope):
+        """Return the name-to-symbol map of the nearest scope that owns a symtable.
 
         Under PEP 709 (Python 3.12+) list, dict and set comprehensions are inlined
         into the enclosing scope and produce no symtable of their own, so their slot
@@ -206,6 +227,9 @@ class FormulaTransformer(m.MatcherDecoratableTransformer):
             if n == prev:
                 raise RuntimeError(f"scope not found for {n.value}")
             scope = self.node_to_scope.get(n, None)
+
+        if self.comprehension_binds(scope, node.value):
+            return False
 
         n_to_s = self.enclosing_symbols(scope)
 

--- a/modelx/export/transformer.py
+++ b/modelx/export/transformer.py
@@ -175,6 +175,25 @@ class FormulaTransformer(m.MatcherDecoratableTransformer):
         self.func_attrs = {}
         self.transformed = self.wrapper.visit(self)
 
+    def enclosing_symbols(self, scope):
+        """The name-to-symbol map of the nearest scope that owns a symtable.
+
+        Under PEP 709 (Python 3.12+) list, dict and set comprehensions are inlined
+        into the enclosing scope and produce no symtable of their own, so their slot
+        in self.name_to_symbol is None and the enclosing scope has to be found
+        lexically. Scanning the flat list backwards instead lands on whichever scope
+        happens to precede them, and a generator expression, lambda or nested def
+        still owns a table.
+        """
+        while scope is not None:
+            i = next((i for i, v in enumerate(self.scopes) if scope is v), None)
+            if i is not None and self.name_to_symbol[i] is not None:
+                return self.name_to_symbol[i]
+            parent = getattr(scope, "parent", None)
+            scope = None if parent is scope else parent    # BuiltinScope.parent is itself
+
+        return self.name_to_symbol[0]       # global scope
+
     def should_replace(self, node: cst.Name):
 
         # Name nodes in import statements are not in the keys of self.node_to_scope
@@ -188,12 +207,7 @@ class FormulaTransformer(m.MatcherDecoratableTransformer):
                 raise RuntimeError(f"scope not found for {n.value}")
             scope = self.node_to_scope.get(n, None)
 
-        i = next(i for i, v in enumerate(self.scopes) if scope == v)
-
-        n_to_s = self.name_to_symbol[i]
-        while n_to_s is None:
-            i -= 1
-            n_to_s = self.name_to_symbol[i]
+        n_to_s = self.enclosing_symbols(scope)
 
         symbol = n_to_s.get(node.value, None)
         if symbol:

--- a/modelx/tests/export/test_export.py
+++ b/modelx/tests/export/test_export.py
@@ -487,16 +487,45 @@ def comprehension_scopes(tmp_path_factory):
         h = lambda t: b(t)
         return d(1), h(1), [d for d in ys]
 
-    @mx.defcells(space=s)
-    def comp_in_default(t, u=sum([i for i in range(3)])):
-        return t + u
-
     nomx_path = tmp_path_factory.mktemp('model')
     m.export(nomx_path / 'CompScope_nomx')
 
     try:
         sys.path.insert(0, str(nomx_path))
         from CompScope_nomx import mx_model as nomx
+        yield m, nomx
+    finally:
+        sys.path.pop(0)
+        m.close()
+
+
+@pytest.fixture(scope="module")
+def comprehension_in_default(tmp_path_factory):
+    """A Space with a comprehension in the default value of a formula parameter
+
+    Kept out of ``comprehension_scopes`` because such a formula cannot be exported
+    at all on Python 3.11 and earlier, for a reason that has nothing to do with
+    what the tests below check: there a comprehension still owns a symtable, and
+    the default value is evaluated in the scope enclosing the def, so symtable
+    makes that table a child of the module while libCST orders the matching
+    ComprehensionScope after the FunctionScope. ``adjust_scope_table_mapping``
+    pairs the two lists by position and its ``assert s.name == t.get_name()``
+    fails. Generator expressions and lambdas in the same position fail the same
+    way on every version.
+    """
+    m = mx.new_model()
+    s = m.new_space("Space1")
+
+    @mx.defcells(space=s)
+    def comp_in_default(t, u=sum([i for i in range(3)])):
+        return t + u
+
+    nomx_path = tmp_path_factory.mktemp('model')
+    m.export(nomx_path / 'CompDefault_nomx')
+
+    try:
+        sys.path.insert(0, str(nomx_path))
+        from CompDefault_nomx import mx_model as nomx
         yield m, nomx
     finally:
         sys.path.pop(0)
@@ -621,14 +650,17 @@ def test_comprehension_loop_var_also_read(comprehension_scopes, name):
     assert nomx.Space1.d(3) == 300
 
 
-def test_comprehension_in_default_value(comprehension_scopes):
+@pytest.mark.skipif(sys.version_info < (3, 12),
+                    reason="a comprehension in a default value cannot be exported "
+                           "before 3.12; see the comprehension_in_default fixture")
+def test_comprehension_in_default_value(comprehension_in_default):
     """A comprehension in a default value is evaluated where ``self`` does not exist
 
     The default values of the generated method are evaluated while the body of the
     generated class is executed, so a ``self.`` there raises ``NameError`` on import
     of the exported package. A default value cannot refer to a Space member anyway.
     """
-    m, nomx = comprehension_scopes
+    m, nomx = comprehension_in_default
 
     assert _formula_source(nomx, 'comp_in_default') == dedent("""\
     def _f_comp_in_default(self, t, u=sum([i for i in range(3)])):

--- a/modelx/tests/export/test_export.py
+++ b/modelx/tests/export/test_export.py
@@ -396,7 +396,7 @@ def test_model_level_ref(tmp_path):
 
 @pytest.fixture(scope="module")
 def comprehension_scopes(tmp_path_factory):
-    """A Space whose formulas put a comprehension next to a scope that owns a symtable.
+    """A Space whose formulas mix comprehensions with the scopes around them.
 
     Since PEP 709 (Python 3.12), list, dict and set comprehensions are inlined into
     the enclosing scope and no longer produce a symtable of their own, so the
@@ -405,9 +405,13 @@ def comprehension_scopes(tmp_path_factory):
     and a comprehension that follows one of them used to be resolved against that
     scope's symtable instead of the formula's.
 
-    ``a``, ``b`` and ``c`` are Cells, so every reference to them must be exported
-    as ``self.a``, ``self.b`` and ``self.c``, except where the name is bound by the
-    comprehension itself.
+    That symtable cannot answer whether a name is the comprehension's own target
+    either, because PEP 709 isolates the target and leaves it indistinguishable
+    from a global of the same name.
+
+    ``a``, ``b``, ``c`` and ``d`` are Cells, so every reference to them must be
+    exported as ``self.a``, ``self.b``, ``self.c`` and ``self.d``, except where the
+    name is bound by the comprehension itself.
     """
     m = mx.new_model()
     s = m.new_space("Space1")
@@ -423,6 +427,10 @@ def comprehension_scopes(tmp_path_factory):
     @mx.defcells(space=s)
     def c(x):
         return 10 * x
+
+    @mx.defcells(space=s)
+    def d(x):
+        return 100 * x
 
     @mx.defcells(space=s)
     def after_genexp():
@@ -457,6 +465,31 @@ def comprehension_scopes(tmp_path_factory):
         ys = [1, 2]
         f = lambda t: a(t)
         return f(1), [a for a in ys]
+
+    @mx.defcells(space=s)
+    def nested_comp_after_genexp():
+        ys = [1, 2]
+        return [sum(b(t) for t in range(y)) for y in ys], [[c(v) for v in [y]] for y in ys]
+
+    @mx.defcells(space=s)
+    def outer_binds_inner_reads():
+        ys = [1, 2]
+        return c(1), [[c for v in [0]] for c in ys]
+
+    @mx.defcells(space=s)
+    def loop_var_also_read():
+        ys = [1, 2]
+        return d(1), [d for d in ys]
+
+    @mx.defcells(space=s)
+    def loop_var_also_read_after_lambda():
+        ys = [1, 2]
+        h = lambda t: b(t)
+        return d(1), h(1), [d for d in ys]
+
+    @mx.defcells(space=s)
+    def comp_in_default(t, u=sum([i for i in range(3)])):
+        return t + u
 
     nomx_path = tmp_path_factory.mktemp('model')
     m.export(nomx_path / 'CompScope_nomx')
@@ -534,6 +567,74 @@ def test_comprehension_loop_var_not_qualified(comprehension_scopes):
     assert nomx.Space1.a(3) == 3
     assert nomx.Space1.shadowing_loop_var() == m.Space1.shadowing_loop_var()
     assert nomx.Space1.a(3) == 3    # 'a' would be an int here if it had been rebound
+
+
+def test_nested_comprehension_after_genexp(comprehension_scopes):
+    """The lexical walk crosses more than one comprehension without a symtable"""
+    m, nomx = comprehension_scopes
+
+    assert _formula_source(nomx, 'nested_comp_after_genexp') == dedent("""\
+    def _f_nested_comp_after_genexp(self):
+        ys = [1, 2]
+        return [sum(self.b(t) for t in range(y)) for y in ys], [[self.c(v) for v in [y]] for y in ys]
+    """)
+    assert (nomx.Space1.nested_comp_after_genexp()
+            == m.Space1.nested_comp_after_genexp())
+
+
+def test_loop_var_read_in_nested_comprehension(comprehension_scopes):
+    """A name bound by an outer comprehension stays bare where an inner one reads it"""
+    m, nomx = comprehension_scopes
+
+    source = _formula_source(nomx, 'outer_binds_inner_reads')
+    assert 'for self.' not in source
+    assert source == dedent("""\
+    def _f_outer_binds_inner_reads(self):
+        ys = [1, 2]
+        return self.c(1), [[c for v in [0]] for c in ys]
+    """)
+
+    assert nomx.Space1.c(3) == 30
+    assert (nomx.Space1.outer_binds_inner_reads()
+            == m.Space1.outer_binds_inner_reads())
+    assert nomx.Space1.c(3) == 30
+
+
+@pytest.mark.parametrize("name", ['loop_var_also_read',
+                                  'loop_var_also_read_after_lambda'])
+def test_comprehension_loop_var_also_read(comprehension_scopes, name):
+    """A loop variable is not qualified even where the Cells is also read by name
+
+    PEP 709 isolates the target of an inlined comprehension, so where the same name
+    is also read as a global in the formula, the symtable of the enclosing scope
+    reports the name as a global and cannot tell the two apart. libCST records the
+    binding in the comprehension's own scope, which can.
+    """
+    m, nomx = comprehension_scopes
+
+    source = _formula_source(nomx, name)
+    assert 'for self.' not in source
+    assert 'self.d(1)' in source
+
+    assert nomx.Space1.d(3) == 300
+    assert getattr(nomx.Space1, name)() == getattr(m.Space1, name)()
+    assert nomx.Space1.d(3) == 300
+
+
+def test_comprehension_in_default_value(comprehension_scopes):
+    """A comprehension in a default value is evaluated where ``self`` does not exist
+
+    The default values of the generated method are evaluated while the body of the
+    generated class is executed, so a ``self.`` there raises ``NameError`` on import
+    of the exported package. A default value cannot refer to a Space member anyway.
+    """
+    m, nomx = comprehension_scopes
+
+    assert _formula_source(nomx, 'comp_in_default') == dedent("""\
+    def _f_comp_in_default(self, t, u=sum([i for i in range(3)])):
+        return t + u
+    """)
+    assert nomx.Space1.comp_in_default(1) == m.Space1.comp_in_default(1) == 4
 
 
 def test_comprehension_before_genexp(comprehension_scopes):

--- a/modelx/tests/export/test_export.py
+++ b/modelx/tests/export/test_export.py
@@ -1,6 +1,8 @@
 import sys
 import os
 import pathlib
+from inspect import getsource
+from textwrap import dedent
 
 import pandas as pd
 import modelx as mx
@@ -390,3 +392,169 @@ def test_model_level_ref(tmp_path):
     finally:
         sys.path.pop(0)
         m.close()
+
+
+@pytest.fixture(scope="module")
+def comprehension_scopes(tmp_path_factory):
+    """A Space whose formulas put a comprehension next to a scope that owns a symtable.
+
+    Since PEP 709 (Python 3.12), list, dict and set comprehensions are inlined into
+    the enclosing scope and no longer produce a symtable of their own, so the
+    exporter has to find the enclosing scope of such a comprehension lexically.
+    A generator expression, a lambda and a nested def each still own a symtable,
+    and a comprehension that follows one of them used to be resolved against that
+    scope's symtable instead of the formula's.
+
+    ``a``, ``b`` and ``c`` are Cells, so every reference to them must be exported
+    as ``self.a``, ``self.b`` and ``self.c``, except where the name is bound by the
+    comprehension itself.
+    """
+    m = mx.new_model()
+    s = m.new_space("Space1")
+
+    @mx.defcells(space=s)
+    def a(x):
+        return x
+
+    @mx.defcells(space=s)
+    def b(x):
+        return x
+
+    @mx.defcells(space=s)
+    def c(x):
+        return 10 * x
+
+    @mx.defcells(space=s)
+    def after_genexp():
+        ys = [1, 2]
+        return [sum(b(t) for t in range(y)) for y in ys], [c(y) for y in ys]
+
+    @mx.defcells(space=s)
+    def after_lambda():
+        ys = [1, 2]
+        f = lambda t: b(t)
+        return f(1), [c(y) for y in ys]
+
+    @mx.defcells(space=s)
+    def after_nested_def():
+        ys = [1, 2]
+        def g(t):
+            return b(t)
+        return g(1), [c(y) for y in ys]
+
+    @mx.defcells(space=s)
+    def before_genexp():
+        ys = [1, 2]
+        return [c(y) for y in ys], [sum(b(t) for t in range(y)) for y in ys]
+
+    @mx.defcells(space=s)
+    def bare_after_genexp():
+        ys = [1, 2]
+        return [sum(b(t) for t in range(y)) for y in ys], c(1)
+
+    @mx.defcells(space=s)
+    def shadowing_loop_var():
+        ys = [1, 2]
+        f = lambda t: a(t)
+        return f(1), [a for a in ys]
+
+    nomx_path = tmp_path_factory.mktemp('model')
+    m.export(nomx_path / 'CompScope_nomx')
+
+    try:
+        sys.path.insert(0, str(nomx_path))
+        from CompScope_nomx import mx_model as nomx
+        yield m, nomx
+    finally:
+        sys.path.pop(0)
+        m.close()
+
+
+def _formula_source(nomx, name):
+    """The source of the method generated for the Cells named ``name``"""
+    return dedent(getsource(getattr(nomx.Space1, '_f_' + name)))
+
+
+def test_comprehension_after_genexp(comprehension_scopes):
+    """A generator expression owns a symtable; the comprehension after it does not"""
+    m, nomx = comprehension_scopes
+
+    assert _formula_source(nomx, 'after_genexp') == dedent("""\
+    def _f_after_genexp(self):
+        ys = [1, 2]
+        return [sum(self.b(t) for t in range(y)) for y in ys], [self.c(y) for y in ys]
+    """)
+    assert nomx.Space1.after_genexp() == m.Space1.after_genexp()
+
+
+def test_comprehension_after_lambda(comprehension_scopes):
+    """A lambda owns a symtable; the comprehension after it does not"""
+    m, nomx = comprehension_scopes
+
+    assert _formula_source(nomx, 'after_lambda') == dedent("""\
+    def _f_after_lambda(self):
+        ys = [1, 2]
+        f = lambda t: self.b(t)
+        return f(1), [self.c(y) for y in ys]
+    """)
+    assert nomx.Space1.after_lambda() == m.Space1.after_lambda()
+
+
+def test_comprehension_after_nested_def(comprehension_scopes):
+    """A nested def owns a symtable; the comprehension after it does not"""
+    m, nomx = comprehension_scopes
+
+    assert _formula_source(nomx, 'after_nested_def') == dedent("""\
+    def _f_after_nested_def(self):
+        ys = [1, 2]
+        def g(t):
+            return self.b(t)
+        return g(1), [self.c(y) for y in ys]
+    """)
+    assert nomx.Space1.after_nested_def() == m.Space1.after_nested_def()
+
+
+def test_comprehension_loop_var_not_qualified(comprehension_scopes):
+    """A loop variable shadowing a Cells name must not be prefixed with ``self.``
+
+    ``for self.a in ys`` is valid Python, so this mode of the defect produces code
+    that imports and runs, silently rebinding the ``a`` Cells on the Space instance.
+    """
+    m, nomx = comprehension_scopes
+
+    source = _formula_source(nomx, 'shadowing_loop_var')
+    assert 'for self.' not in source
+    assert source == dedent("""\
+    def _f_shadowing_loop_var(self):
+        ys = [1, 2]
+        f = lambda t: self.a(t)
+        return f(1), [a for a in ys]
+    """)
+
+    assert nomx.Space1.a(3) == 3
+    assert nomx.Space1.shadowing_loop_var() == m.Space1.shadowing_loop_var()
+    assert nomx.Space1.a(3) == 3    # 'a' would be an int here if it had been rebound
+
+
+def test_comprehension_before_genexp(comprehension_scopes):
+    """A comprehension preceding any generator expression stays correct"""
+    m, nomx = comprehension_scopes
+
+    assert _formula_source(nomx, 'before_genexp') == dedent("""\
+    def _f_before_genexp(self):
+        ys = [1, 2]
+        return [self.c(y) for y in ys], [sum(self.b(t) for t in range(y)) for y in ys]
+    """)
+    assert nomx.Space1.before_genexp() == m.Space1.before_genexp()
+
+
+def test_plain_name_after_genexp(comprehension_scopes):
+    """A reference outside any comprehension stays correct after a generator expression"""
+    m, nomx = comprehension_scopes
+
+    assert _formula_source(nomx, 'bare_after_genexp') == dedent("""\
+    def _f_bare_after_genexp(self):
+        ys = [1, 2]
+        return [sum(self.b(t) for t in range(y)) for y in ys], self.c(1)
+    """)
+    assert nomx.Space1.bare_after_genexp() == m.Space1.bare_after_genexp()


### PR DESCRIPTION
Fixes two ways `Model.export` could generate wrong code for a name inside a list,
dict or set comprehension. Both live in `FormulaTransformer.should_replace`.

Found by exporting all 28 uslib/uklib/jplib models of lifelib:
`DIA_US_S.Projection.result_annual` came out with five bare names and raised
`NameError` on the first call. The other 27 exported clean.

## 1. Resolve the enclosing scope lexically (b450515)

PEP 709 (Python 3.12) inlines list, dict and set comprehensions into the enclosing
scope, so they no longer produce a symtable. `adjust_scope_table_mapping` compensates
by inserting `None` into `self.symtables` for each such scope, keeping it aligned with
`self.scopes`. `should_replace` then found the enclosing scope's table by scanning the
flat list *backwards* for the nearest non-`None` entry.

Nearest-earlier-table is not enclosing-scope. Generator expressions, lambdas and
nested `def`s all still own tables, and a comprehension only has to follow one of them
in the same formula to be resolved against it:

```python
def with_genexp():
    ys = [1, 2]
    return {
        "a": [a(y) for y in ys],
        "b": [sum(b(t) for t in range(y)) for y in ys],
        "c": [c(y) for y in ys],       # resolved against the genexp's table -> bare
    }
```

`enclosing_symbols` replaces the scan and walks the libCST scope's own `parent` chain
until it reaches a scope that owns a table.

## 2. Never qualify a name the comprehension itself binds (c67e51f)

**These two commits have to ship together.** Resolving the scope correctly exposes the
fact that under PEP 709 the enclosing symtable is *lossy*: it cannot distinguish an
inlined comprehension's isolated target from a global of the same name. Commit 1 alone
regresses two shapes that `main` gets right:

| shape | `main` | commit 1 alone |
| --- | --- | --- |
| `def f(t, u=[i for i in range(3)])` | correct | `u=[self.i for self.i in ...]`, and `self` does not exist while the generated class body executes, so the exported package fails to **import** |
| `def f(): return d(1), [d for d in ys]`, with a lambda / genexp / nested `def` in between | correct | `[self.d for self.d in ys]` |

The second is the dangerous mode: `for self.d in ys` is valid Python — an attribute is
a legal assignment target — so the exported model imports and runs, silently rebinds
the `d` Cells on the Space instance, and every later call to that Cells fails somewhere
that points nowhere near the formula that broke it.

`comprehension_binds` asks libCST instead, which records the binding in the
comprehension's own scope, where nothing is inlined and nothing is ambiguous. It also
closes the same defect in the no-intervening-scope case, `def f(): return d(1),
[d for d in ys]`, which was already wrong on `main`.

The first iterable is deliberately not covered: libCST records it in the enclosing
scope, exactly as Python evaluates it there, so `[c for c in c]` still qualifies the
iterable and leaves the two bound occurrences alone.

Python 3.11 and earlier are unaffected by either change. The `None` slots are inserted
only under `sys.version_info >= (3, 12)`, so the backward scan never ran there, and a
comprehension that owns a symtable already reports its target as a local.

## Tests

Eleven items in `modelx/tests/export/test_export.py`, off one module-scoped fixture,
following the `test_cacheless.py` idiom of asserting on `getsource` of the generated
method. Seven fail on `main`:

* comprehension after a generator expression, after a lambda, after a nested `def`
* a nested comprehension after a generator expression — the only shape that walks more
  than one level; the 28-model corpus never does
* a loop variable shadowing a Cells name, and one that is also read by name in the
  same formula, both with a runtime assertion that the Cells still answers after the
  formula has run
* a name bound by an outer comprehension and read inside an inner one

Four pass on `main` and are there to keep this change from regressing them: a
comprehension *before* any generator expression, a plain reference after one, a
comprehension in a parameter default, and the loop-variable-also-read case with an
intervening lambda.

## Verification

* `modelx/tests/export/` 50 passed; full suite 1405 passed, 6 skipped.
* Reproduced on `main` and fixed here under Python 3.12.9, 3.13.9 and 3.14.7. There is
  no 3.11-or-earlier interpreter on this machine, so that path is read from the code,
  not tested. (`test_lifelib.py` crashes on the free-threaded 3.14 build with a C-stack
  overflow inside modelx's own evaluation — pre-existing on `main`, unrelated.)
* **Corpus:** re-exporting all 28 uslib/uklib/jplib models at lifelib 6d5b078 changes
  exactly one hunk of 69,142 generated lines — the six lines of
  `DIA_US_S.Projection.result_annual` — and a symtable scan for names that resolve to
  nothing goes from 5 hits to 0.
* Exported from `main`, `DIA_US_S.Projection.result_annual` raises `NameError`; with
  this change it reproduces the modelx original frame for frame.
* The twelve models covered by `test_lifelib.py` export byte-identically. The only raw
  differences are the `id()` literals the exporter embeds for IO and pickle data, and a
  `fixed`-vs-`fixed` run produces the same noise, so it is not from this change.

## For the reviewer

* The release note went into a new `relnotes_v0_33_0.rst` marked *not yet released*,
  following the draft pattern of 09671df, since 0.32.0 has shipped. Rename it if the
  next release is 0.32.1.
* I skipped the `id(scope)`-keyed dict tidy-up that would replace the linear scan in
  `enclosing_symbols`. Measured over 12 uslib models it is 0.98x — libCST parsing
  dominates and the scan is free. Happy to add it if you want it anyway.
* `return self.name_to_symbol[0]` in `enclosing_symbols` is a fallback that appears to
  be unreachable: instrumented over the 28-model corpus, 27,159 lookups never reached
  it. Left as a fallback rather than an assertion, but it could be either.
* Seven **pre-existing** exporter defects surfaced while working on this, none of them
  touched here. Filed separately as #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
