### PR TITLE
Export models with __slots__ on the generated Space classes

### DIFF
--- a/devnotes/DependentPackages.md
+++ b/devnotes/DependentPackages.md
@@ -193,6 +193,21 @@ uncompiled plain module — mx2cy with macro-bearing models is untested
 territory. Any further new module kinds in the exporter should be checked
 against modelx-cython.
 
+**Known break — `__slots__` on the exported Space classes:** modelx v0.33.0
+makes `Model.export`/`export_model` declare `__slots__` on every generated
+`_c_<Space>` class, and adds `__slots__ = ()` to `BaseMxObject`, `BaseParent`
+and `BaseSpace` in `_mx_sys.py` in both modes. `tracer.py:625`
+(`for name, val in tr0.arg_vals[MX_SELF].__dict__.items()` in
+`MxCallTraceLogger.flush`) reads the traced Space instance's `__dict__` to
+discover its refs, and a slotted instance has none, so type tracing fails for
+every Space of every model. The generated model class is left unslotted and is
+unaffected. Until modelx-cython walks `__slots__` across the MRO as well,
+mx2cy input must be exported with `use_slots=False`. Once it is fixed,
+`leave_ClassDef` should also strip the `__slots__` assignment where it attaches
+`@cy.cclass`: Cython accepts `__slots__` inside a `cdef class` and ignores it
+for storage, so it survives as an inert class attribute naming fields that are
+unreachable via `getattr`.
+
 ### 2.3 Serializer-format couplings (test fixtures)
 
 - Eleven sample model directories under `modelx_cython/tests/samples/`

--- a/doc/source/releases/relnotes_v0_33_0.rst
+++ b/doc/source/releases/relnotes_v0_33_0.rst
@@ -2,7 +2,8 @@
 modelx v0.33.0 (not yet released)
 ====================================
 
-This release introduces the following bug fixes.
+This release introduces the following enhancements, backward-incompatible
+changes and bug fixes.
 
 To update modelx to the latest version, use the following command::
 
@@ -11,6 +12,46 @@ To update modelx to the latest version, use the following command::
 Anaconda users should use the ``conda`` command instead::
 
     >>> conda update modelx
+
+
+Enhancements
+============
+
+* The Space classes that
+  :meth:`Model.export<modelx.core.model.Model.export>` and
+  :func:`~modelx.export_model` generate now declare ``__slots__``.
+  CPython keeps slotted attributes in a fixed-size array instead of an
+  instance dictionary and specialises the bytecode that reads them, so the
+  exported model runs faster and takes less memory.
+  Measured on ``BasicTerm_SC`` of the ``basiclife`` library of
+  `lifelib <https://lifelib.io>`_, 3,000 model points per round and the best
+  of three rounds, the run is 21% faster on Python 3.13 and 28% faster on
+  Python 3.14, and an ItemSpace of ``Projection`` takes 616 bytes instead of
+  1,632.
+
+  Pass ``use_slots=False`` to
+  :meth:`Model.export<modelx.core.model.Model.export>` or
+  :func:`~modelx.export_model` to generate the same output as modelx v0.32.0.
+
+
+Backward Incompatible Changes
+==============================
+
+* Because the exported Space classes declare ``__slots__``, Space objects in
+  an exported model are no longer weak-referenceable, and attributes cannot
+  be added to them at run time.
+  `modelx-cython <https://github.com/fumitoh/modelx-cython>`_ also cannot
+  compile a model exported this way until it is updated to read ``__slots__``.
+  Export with ``use_slots=False`` in either case.
+
+* :meth:`Model.export<modelx.core.model.Model.export>` and
+  :func:`~modelx.export_model` now raise :obj:`ValueError` when a name
+  assigned as an attribute of a Space is also the name of a method of the
+  generated class, which in practice means a Cells sharing its name with a
+  parameter of its own Space or of an enclosing Space. Such a name has always
+  been exported incorrectly, because the parameter value is assigned over the
+  method, and it cannot be declared in ``__slots__`` at all. Rename one of the
+  two, or export with ``use_slots=False``.
 
 
 Bug Fixes

--- a/doc/source/releases/relnotes_v0_33_0.rst
+++ b/doc/source/releases/relnotes_v0_33_0.rst
@@ -49,12 +49,14 @@ Backward Incompatible Changes
 
 * :meth:`Model.export<modelx.core.model.Model.export>` and
   :func:`~modelx.export_model` now raise :obj:`ValueError` when a name
-  assigned as an attribute of a Space is also the name of a method of the
-  generated class, which in practice means a Cells sharing its name with a
-  parameter of its own Space or of an enclosing Space. Such a name has always
-  been exported incorrectly, because the parameter value is assigned over the
-  method, and it cannot be declared in ``__slots__`` at all. Rename one of the
-  two, or export with ``use_slots=False``.
+  assigned as an attribute of a Space is also defined by the generated class,
+  because ``__slots__`` cannot declare such a name. In practice that is a
+  Cells sharing its name with a parameter of its own Space or of an enclosing
+  Space, or with a Reference of the Space including a model-level global; it
+  is also a Space parameter named after a member of ``_mx_sys.BaseSpace``,
+  such as ``_cells``. Most such names are exported incorrectly today, because
+  the attribute is assigned over the method. Rename one of the two, or export
+  with ``use_slots=False``.
 
 
 Bug Fixes

--- a/doc/source/releases/relnotes_v0_33_0.rst
+++ b/doc/source/releases/relnotes_v0_33_0.rst
@@ -37,12 +37,15 @@ Enhancements
 Backward Incompatible Changes
 ==============================
 
-* Because the exported Space classes declare ``__slots__``, Space objects in
-  an exported model are no longer weak-referenceable, and attributes cannot
-  be added to them at run time.
-  `modelx-cython <https://github.com/fumitoh/modelx-cython>`_ also cannot
-  compile a model exported this way until it is updated to read ``__slots__``.
-  Export with ``use_slots=False`` in either case.
+* Because the exported Space classes declare ``__slots__``, their attributes
+  are fixed when the model is exported. A macro or a formula that assigns a
+  Reference the model does not already have now raises :obj:`AttributeError`
+  in the exported model. Space objects there are also no longer
+  weak-referenceable, have no ``__dict__``, and cannot be pickled with pickle
+  protocol 0 or 1.
+  `modelx-cython <https://github.com/fumitoh/modelx-cython>`_ cannot compile a
+  model exported this way either, until it is updated to read ``__slots__``.
+  Export with ``use_slots=False`` in any of these cases.
 
 * :meth:`Model.export<modelx.core.model.Model.export>` and
   :func:`~modelx.export_model` now raise :obj:`ValueError` when a name

--- a/modelx/core/api.py
+++ b/modelx/core/api.py
@@ -1411,6 +1411,11 @@ def export_model(model, path, use_slots=True):
       already have raises :obj:`AttributeError` in the exported model.
     * Space objects in the exported model are not weak-referenceable, have no
       ``__dict__``, and cannot be pickled with pickle protocol 0 or 1.
+    * The export raises :obj:`ValueError` when a name assigned as an
+      attribute of a Space is also defined by the generated class, because
+      ``__slots__`` cannot declare it. In practice that is a Cells sharing
+      its name with a parameter of its own Space or of an enclosing Space,
+      or with a Reference, including a model-level global.
     * `modelx-cython`_ cannot compile an export made this way until it is
       updated.
 

--- a/modelx/core/api.py
+++ b/modelx/core/api.py
@@ -1348,7 +1348,7 @@ def handle_formula_error(handle=None):
     return _system.executor.is_formula_error_handled
 
 
-def export_model(model, path):
+def export_model(model, path, use_slots=True):
     """Export a given model as a self-contained Python package.
 
     .. warning:: This function is currently experimental
@@ -1398,15 +1398,35 @@ def export_model(model, path):
       Users should ensure that such Cells are called using ``()``
       in the original model's formulas.
 
+    **__slots__**
+
+    The generated Space classes declare ``__slots__`` by default. This makes
+    the exported model faster and smaller, because CPython stores slotted
+    attributes in a fixed-size array and specialises the bytecode that reads
+    them. Two consequences to be aware of:
+
+    * Space objects in the exported model are not weak-referenceable, and
+      no attribute can be added to them at run time.
+    * `modelx-cython`_ cannot compile an export made this way until it is
+      updated. Pass ``use_slots=False`` to export as modelx v0.32.0 and
+      earlier does.
+
+    .. _modelx-cython: https://github.com/fumitoh/modelx-cython
+
     Args:
         model: The Model object to be exported.
         path: The path where the generated Python package will be located.
+        use_slots(:obj:`bool`, optional): Whether the generated Space classes
+            declare ``__slots__``. Defaults to :obj:`True`.
 
     .. seealso:: :meth:`~modelx.core.model.Model.export`
     .. versionadded:: 0.22.0
+    .. versionchanged:: 0.33.0
+        The ``use_slots`` parameter is added, and the generated Space classes
+        declare ``__slots__`` by default.
     """
     from ..export.exporter import Exporter
-    Exporter(model, path).export()
+    Exporter(model, path, use_slots=use_slots).export()
 
 
 def _new_cells_keep_source(space, formula):

--- a/modelx/core/api.py
+++ b/modelx/core/api.py
@@ -1403,13 +1403,19 @@ def export_model(model, path, use_slots=True):
     The generated Space classes declare ``__slots__`` by default. This makes
     the exported model faster and smaller, because CPython stores slotted
     attributes in a fixed-size array and specialises the bytecode that reads
-    them. Two consequences to be aware of:
+    them. The consequences to be aware of:
 
-    * Space objects in the exported model are not weak-referenceable, and
-      no attribute can be added to them at run time.
+    * The attributes are fixed when the model is exported, so an attribute
+      that does not exist by then cannot be added at run time. In particular,
+      a macro or a formula that assigns a Reference the model does not
+      already have raises :obj:`AttributeError` in the exported model.
+    * Space objects in the exported model are not weak-referenceable, have no
+      ``__dict__``, and cannot be pickled with pickle protocol 0 or 1.
     * `modelx-cython`_ cannot compile an export made this way until it is
-      updated. Pass ``use_slots=False`` to export as modelx v0.32.0 and
-      earlier does.
+      updated.
+
+    Pass ``use_slots=False`` in any of these cases to export as
+    modelx v0.32.0 and earlier does.
 
     .. _modelx-cython: https://github.com/fumitoh/modelx-cython
 

--- a/modelx/core/model.py
+++ b/modelx/core/model.py
@@ -560,7 +560,7 @@ class Model(IOSpecOperation, EditableParent):
                     backup=backup, log_input=log_input,
                     compression=compression, compresslevel=compresslevel)
 
-    def export(self, path):
+    def export(self, path, use_slots=True):
         """Export the model as a Python package.
 
         .. warning:: This feature is experimental.
@@ -569,10 +569,19 @@ class Model(IOSpecOperation, EditableParent):
         This method performs the :py:func:`~modelx.export_model`
         on self. See :py:func:`~modelx.export_model` section for the details.
 
+        Args:
+            path: The path where the generated Python package will be located.
+            use_slots(:obj:`bool`, optional): Whether the generated Space
+                classes declare ``__slots__``. Defaults to :obj:`True`.
+                See :py:func:`~modelx.export_model`.
+
         .. versionadded:: 0.22.0
+        .. versionchanged:: 0.33.0
+            The ``use_slots`` parameter is added, and the generated Space
+            classes declare ``__slots__`` by default.
         """
         from ..export.exporter import Exporter
-        Exporter(self, path).export()
+        Exporter(self, path, use_slots=use_slots).export()
 
     # ----------------------------------------------------------------------
     # Getting and setting attributes

--- a/modelx/export/_mx_sys.py
+++ b/modelx/export/_mx_sys.py
@@ -12,10 +12,15 @@ except ImportError:
 
 
 class BaseMxObject:
-    pass
+
+    __slots__ = ()
 
 
 class BaseParent(BaseMxObject):
+
+    # Annotations only: they create no class attributes and so never
+    # conflict with the __slots__ of a subclass.
+    __slots__ = ()
 
     _mx_spaces: Dict[str, 'BaseSpace']
     _parent: 'BaseParent'
@@ -68,6 +73,10 @@ class BaseModel(BaseParent):
 
 
 class BaseSpace(BaseParent):
+
+    # Subclasses generated with use_slots=False declare no __slots__ of
+    # their own and so still get a __dict__, exactly as before.
+    __slots__ = ()
 
     # Instance variables
     _mx_is_cells_set: bool

--- a/modelx/export/exporter.py
+++ b/modelx/export/exporter.py
@@ -19,6 +19,7 @@ import textwrap
 import types
 import pprint
 import inspect
+import unicodedata
 try:
     from functools import cached_property
 except ImportError:     # - Python 3.7
@@ -50,11 +51,25 @@ SPACE_CLS_PREFIX = '_c_'
 
 # Members a generated Space class inherits from the _mx_sys template. A
 # __slots__ entry repeating one of them silently shadows it - a slot named
-# _cells would take over the property that populates _mx_cells. Only Space
-# parameters can produce such a name; modelx rejects a leading underscore in
-# the name of a Cells, a Reference or a Space.
+# _cells would take over the property that populates _mx_cells. Every one of
+# them starts with an underscore, and the only slot names that can is a Space
+# parameter: modelx rejects a leading underscore in the name of a Reference or
+# a Space, and a Cells name only ever reaches __slots__ behind a _v_ or _has_
+# prefix.
 INHERITED_ATTRS = frozenset(
     name for klass in _mx_sys.BaseSpace.__mro__ for name in vars(klass))
+
+
+def normalize(name):
+    """Return ``name`` as the compiler stores it.
+
+    Python normalises every identifier in a source file to NFKC, but a
+    ``__slots__`` entry is a string and is not normalised. A Reference named
+    with a fullwidth letter, which :meth:`str.isidentifier` accepts and modelx
+    keeps verbatim, is therefore assigned under its normalised name and has to
+    be declared under that name too.
+    """
+    return unicodedata.normalize('NFKC', name)
 
 
 def mangle(class_name, name):
@@ -66,8 +81,9 @@ def mangle(class_name, name):
     in the body of the Space that owns the parameter, so a descendant Space
     must declare the owner's form of the name, not its own.
     """
+    name = normalize(name)
     if name.startswith('__') and not name.endswith('__'):
-        return '_' + class_name.lstrip('_') + name
+        return '_' + normalize(class_name).lstrip('_') + name
 
     return name
 
@@ -587,6 +603,7 @@ class SpaceTranslator(ParentTranslator):
         class_names = set(INHERITED_ATTRS)
         class_names.update(['__init__', '_mx_assign_refs', '_mx_copy_refs'])
         for name in trans.func_attrs:
+            name = normalize(name)
             class_names.add(name)                   # the Cells method
             if name not in cacheless:
                 class_names.add('_f_' + name)       # its underlying formula
@@ -721,9 +738,9 @@ class SpaceTranslator(ParentTranslator):
         """Render the ``__slots__`` declaration of ``space``'s class.
 
         ``names`` are the attributes assigned on instances of the class, in
-        the order they are assigned and possibly with duplicates.
-        ``class_names`` are the names bound in the class body, which a slot
-        must not repeat. Returns an empty string when ``use_slots`` is false,
+        the order they are assigned, possibly with duplicates and not
+        necessarily normalised. ``class_names`` are the names the class binds
+        or inherits, which a slot must not repeat. Returns an empty string when ``use_slots`` is false,
         in which case the generated class is byte-identical to the one
         modelx v0.32.0 generates.
         """
@@ -732,15 +749,16 @@ class SpaceTranslator(ParentTranslator):
 
         slots = []
         for name in names:
+            name = normalize(name)
             if name in class_names:
                 raise ValueError(
                     "%s cannot be exported with use_slots=True: the name %r "
-                    "is assigned as an attribute of the Space but is also a "
-                    "member of the exported class, either a Cells of the "
-                    "same name or an inherited member. The attribute shadows "
-                    "the member, so the exported model is incorrect for this "
-                    "name either way. Rename one of the two, or pass "
-                    "use_slots=False to export as modelx v0.32.0 does."
+                    "is assigned as an attribute of the Space, but the "
+                    "exported class also defines it, either as a Cells of "
+                    "the same name or as an inherited member. __slots__ "
+                    "cannot declare a name that the class already binds. "
+                    "Rename one of the two, or pass use_slots=False to "
+                    "export as modelx v0.32.0 does."
                     % (space.fullname, name))
             if name not in slots:
                 slots.append(name)

--- a/modelx/export/exporter.py
+++ b/modelx/export/exporter.py
@@ -34,6 +34,7 @@ from modelx.core.cells import Cells
 from modelx.serialize.ziputil import write_str_utf8, copy_file
 from modelx.core.util import abs_to_rel_tuple
 
+from . import _mx_sys
 from .transformer import (
     FormulaTransformer, lambda_to_func, is_lambda_expr, get_func_attrs)
 
@@ -46,6 +47,29 @@ DATA_MODULE = '_mx_io'  # _mx_io is hard-coded in _mx_sys
 MACRO_MODULE = '_mx_macros'
 SPACE_PKG_PREFIX = '_m_'
 SPACE_CLS_PREFIX = '_c_'
+
+# Members a generated Space class inherits from the _mx_sys template. A
+# __slots__ entry repeating one of them silently shadows it - a slot named
+# _cells would take over the property that populates _mx_cells. Only Space
+# parameters can produce such a name; modelx rejects a leading underscore in
+# the name of a Cells, a Reference or a Space.
+INHERITED_ATTRS = frozenset(
+    name for klass in _mx_sys.BaseSpace.__mro__ for name in vars(klass))
+
+
+def mangle(class_name, name):
+    """Apply CPython's private name mangling to ``name``.
+
+    A name of the form ``__x`` is mangled with the class whose body it
+    appears in, and a ``__slots__`` entry is mangled with the class that
+    declares it. ``_mx_assign_params`` and ``_mx_copy_params`` are compiled
+    in the body of the Space that owns the parameter, so a descendant Space
+    must declare the owner's form of the name, not its own.
+    """
+    if name.startswith('__') and not name.endswith('__'):
+        return '_' + class_name.lstrip('_') + name
+
+    return name
 
 
 def get_space_formula_attrs(space: BaseSpace):
@@ -557,9 +581,11 @@ class SpaceTranslator(ParentTranslator):
 
         trans = FormulaTransformer(source, cells, cacheless)
 
-        # Names bound in the generated class body. A __slots__ entry equal to
-        # any of them makes the class definition raise ValueError.
-        class_names = {'__init__', '_mx_assign_refs', '_mx_copy_refs'}
+        # Names the generated class body binds or inherits. A __slots__ entry
+        # equal to one bound in the class body makes the class definition
+        # raise ValueError; one equal to an inherited name shadows it.
+        class_names = set(INHERITED_ATTRS)
+        class_names.update(['__init__', '_mx_assign_refs', '_mx_copy_refs'])
         for name in trans.func_attrs:
             class_names.add(name)                   # the Cells method
             if name not in cacheless:
@@ -684,7 +710,9 @@ class SpaceTranslator(ParentTranslator):
         parent = space.parent
         while isinstance(parent, BaseSpace):
             if parent.formula:
-                result[:0] = get_space_formula_attrs(parent).params
+                class_name = SPACE_CLS_PREFIX + parent.name
+                result[:0] = [mangle(class_name, k) for k
+                              in get_space_formula_attrs(parent).params]
             parent = parent.parent
 
         return result
@@ -707,10 +735,10 @@ class SpaceTranslator(ParentTranslator):
             if name in class_names:
                 raise ValueError(
                     "%s cannot be exported with use_slots=True: the name %r "
-                    "is assigned as an attribute of the Space but is also "
-                    "defined as a method of the exported class, most likely "
-                    "by a Cells of the same name. The attribute shadows the "
-                    "method, so the exported model is incorrect for this "
+                    "is assigned as an attribute of the Space but is also a "
+                    "member of the exported class, either a Cells of the "
+                    "same name or an inherited member. The attribute shadows "
+                    "the member, so the exported model is incorrect for this "
                     "name either way. Rename one of the two, or pass "
                     "use_slots=False to export as modelx v0.32.0 does."
                     % (space.fullname, name))

--- a/modelx/export/exporter.py
+++ b/modelx/export/exporter.py
@@ -48,11 +48,25 @@ SPACE_PKG_PREFIX = '_m_'
 SPACE_CLS_PREFIX = '_c_'
 
 
+def get_space_formula_attrs(space: BaseSpace):
+    """Return the FuncAttrs of a parameterized Space's formula.
+
+    ``space.formula`` must not be None. The parameter assignments and the
+    ``__slots__`` entries for them are both derived from the result, so that
+    the two cannot disagree.
+    """
+    src = space.formula.source
+    if is_lambda_expr(src):
+        src = lambda_to_func(src, '_formula')
+    return get_func_attrs(src)
+
+
 class Exporter:
 
-    def __init__(self, model: Model, path):
+    def __init__(self, model: Model, path, use_slots: bool = True):
         self.model = model
         self.path = pathlib.Path(path)
+        self.use_slots = use_slots
 
     def gen_parents(self):
         """Generator yielding model and spaces in breadth-first order"""
@@ -99,7 +113,7 @@ class Exporter:
 
                 # Write space modules
                 write_str_utf8(
-                    SpaceTranslator(parent, io_manager).code,
+                    SpaceTranslator(parent, io_manager, self.use_slots).code,
                     cur_dir / (SPACE_MODULE + '.py'))
 
         # Write IO metadata
@@ -213,14 +227,33 @@ class ParentTranslator:
     def class_defs(self):
         raise NotImplementedError
 
+    def ref_names(self, parent):
+        """Names of the References assigned as attributes of ``parent``.
+
+        The single source of truth for :meth:`ref_assigns`,
+        :meth:`ref_copies` and, in :class:`SpaceTranslator`, for the
+        ``__slots__`` entries of the References.
+        """
+        return [k for k in parent.refs if k[0] != "_"]
+
+    def space_names(self, parent):
+        """Names of the child Spaces assigned as attributes of ``parent``.
+
+        The single source of truth for :meth:`space_assigns`,
+        :meth:`space_dict` and, in :class:`SpaceTranslator`, for the
+        ``__slots__`` entries of the child Spaces.
+        """
+        return [k for k in parent.spaces if k[0] != "_"]
+
     def ref_assigns(self, parent, copy=False):
         result = []
-        for k, v in parent.refs.items():
-            if k[0] != "_":
-                if copy:
-                    result.append('self.' + k + ' = other.' + k)
-                else:
-                    result.append('self.' + k + ' = ' + self.ref_value(parent, v))
+        for k in self.ref_names(parent):
+            if copy:
+                result.append('self.' + k + ' = other.' + k)
+            else:
+                result.append(
+                    'self.' + k + ' = '
+                    + self.ref_value(parent, parent.refs[k]))
 
         if result:
             result.insert(0, "# Reference assignment")
@@ -231,9 +264,8 @@ class ParentTranslator:
 
     def ref_copies(self, parent):
         result = []
-        for k, v in parent.refs.items():
-            if k[0] == "_":
-                continue
+        for k in self.ref_names(parent):
+            v = parent.refs[k]
 
             base_k = 'base.' + k
             self_k = 'self.' + k
@@ -285,9 +317,8 @@ class ParentTranslator:
 
     def space_dict(self, parent):
         elms = []
-        for k, v in parent.spaces.items():
-            if k[0] != "_":
-                elms.append("'" + k + "'" + ': self.' + k)
+        for k in self.space_names(parent):
+            elms.append("'" + k + "'" + ': self.' + k)
 
         return self.space_dict_template.format(
             elements=textwrap.indent(",\n".join(elms), ' ' * 4)
@@ -336,10 +367,9 @@ class ModelTranslator(ParentTranslator):
 
     def space_assigns(self, parent):
         result = []
-        for k, v in parent.spaces.items():
-            if k[0] != "_":
-                result.append(
-                    'self.' + k + " = " + SPACE_MODULE + "." + SPACE_CLS_PREFIX + k + "(self)")
+        for k in self.space_names(parent):
+            result.append(
+                'self.' + k + " = " + SPACE_MODULE + "." + SPACE_CLS_PREFIX + k + "(self)")
         if result:
             result.insert(0, "# Space assignments")
 
@@ -362,7 +392,7 @@ class SpaceTranslator(ParentTranslator):
 
 
     class _c_{name}(_mx_sys.BaseSpace):
-
+    {slots_decl}
         def __init__(self, parent):
 
             # modelx variables
@@ -398,6 +428,19 @@ class SpaceTranslator(ParentTranslator):
 
     {delitem}
     """)
+
+    # Attributes that ``class_template`` assigns in ``__init__`` on its own,
+    # in the order they appear there. Everything else is contributed by one of
+    # the placeholders and is collected in ``_get_class_def``.
+    template_attrs = (
+        '_space', '_parent', '_model', '_name',
+        '_mx_cells', '_mx_is_cells_set', '_mx_roots')
+
+    slots_template = """
+    __slots__ = (
+{names}
+    )
+"""
 
     cache_method_noparam = textwrap.dedent("""\
     def {name}(self):
@@ -473,6 +516,11 @@ class SpaceTranslator(ParentTranslator):
         del self._mx_itemspaces[item]
     """)
 
+    def __init__(self, parent: BaseParent, io_manager: DataManager,
+                 use_slots: bool = True):
+        super().__init__(parent, io_manager)
+        self.use_slots = use_slots
+
     @cached_property
     def class_defs(self):
         defs = []
@@ -488,9 +536,8 @@ class SpaceTranslator(ParentTranslator):
         # Add dummy ref assignments to function definitions.
         # These assignments are removed by FormulaTransformer.
         lines = []
-        for k, v in space.refs.items():
-            if k[0] != '_':
-                lines.append(k + ' = None')
+        for k in self.ref_names(space):
+            lines.append(k + ' = None')
 
         for k, v in space.cells.items():
             src = v.formula.source
@@ -510,14 +557,30 @@ class SpaceTranslator(ParentTranslator):
 
         trans = FormulaTransformer(source, cells, cacheless)
 
+        # Names bound in the generated class body. A __slots__ entry equal to
+        # any of them makes the class definition raise ValueError.
+        class_names = {'__init__', '_mx_assign_refs', '_mx_copy_refs'}
+        for name in trans.func_attrs:
+            class_names.add(name)                   # the Cells method
+            if name not in cacheless:
+                class_names.add('_f_' + name)       # its underlying formula
+
+        # __slots__ entries. Each name is collected next to the statement
+        # that assigns the attribute, so that the two cannot drift apart.
+        slot_names = list(self.template_attrs)
+        slot_names.extend(self.space_names(space))      # space_assigns
+        slot_names.append('_mx_spaces')                 # space_dict
+
         cache_vars = []
         cache_methods = []
         for func in trans.func_attrs.values():
             if func.name in cacheless:
                 continue
             elif len(func.params) > 0:
+                value_attr = "_v_" + func.name
+                slot_names.append(value_attr)
                 cache_vars.append(
-                    "self._v_" + func.name + " = {}")
+                    "self." + value_attr + " = {}")
                 cache_methods.append(self.cache_method.format(
                     name=func.name,
                     params=func.param_str,
@@ -525,22 +588,30 @@ class SpaceTranslator(ParentTranslator):
                     idx_args=func.key_str
                 ))
             else:
+                value_attr = "_v_" + func.name
+                has_attr = "_has_" + func.name
+                slot_names.append(value_attr)
+                slot_names.append(has_attr)
                 cache_vars.append(
-                    "self._v_" + func.name + " = None")
+                    "self." + value_attr + " = None")
                 cache_vars.append(
-                    "self._has_" + func.name + " = False")
+                    "self." + has_attr + " = False")
                 cache_methods.append(
                     self.cache_method_noparam.format(name=func.name))
         if cache_vars:
             cache_vars.insert(0, "# Cache variables")
 
+        slot_names.extend(self.ref_names(space))    # ref_assigns / ref_copies
+
         # ItemSpace
         if space.formula:
             itemspace_dict = "self._mx_itemspaces = {}"
-            src = space.formula.source
-            if is_lambda_expr(src):
-                src = lambda_to_func(src, '_formula')
-            attrs = get_func_attrs(src)
+            slot_names.append('_mx_itemspaces')
+            attrs = get_space_formula_attrs(space)
+            slot_names.extend(attrs.params)         # _mx_assign_params
+            class_names.update([
+                '_mx_copy_params', '_mx_assign_params',
+                '__call__', '__getitem__', '__delitem__'])
 
             # How to pass args from __getitem__ to __call__
             if len(attrs.params) == len(attrs.required_params) == 1:
@@ -566,8 +637,13 @@ class SpaceTranslator(ParentTranslator):
             getitem = ''
             delitem = ''
 
+        # _mx_copy_params on the enclosing ItemSpace roots assigns their
+        # parameters here as well. See inherited_param_names.
+        slot_names.extend(self.inherited_param_names(space))
+
         return self.class_template.format(
             name=space.name,
+            slots_decl=self.slots_decl(space, slot_names, class_names),
             cells_name_list=textwrap.indent(self.cells_name_list(space), ' ' * 4),
             space_param_list=textwrap.indent(self.space_param_list(space), ' ' * 4),
             space_assigns=textwrap.indent(self.space_assigns(space), ' ' * 8),
@@ -586,15 +662,69 @@ class SpaceTranslator(ParentTranslator):
 
     def space_assigns(self, parent):
         result = []
-        for k, v in parent.spaces.items():
-            if k[0] != "_":
-                pkg = SPACE_PKG_PREFIX + parent.name + '.'
-                result.append(
-                    'self.' + k + " = " + pkg + SPACE_MODULE + "." + SPACE_CLS_PREFIX + k + "(self)")
+        for k in self.space_names(parent):
+            pkg = SPACE_PKG_PREFIX + parent.name + '.'
+            result.append(
+                'self.' + k + " = " + pkg + SPACE_MODULE + "." + SPACE_CLS_PREFIX + k + "(self)")
         if result:
             result.insert(0, "# Space assignments")
 
         return "\n".join(result)
+
+    def inherited_param_names(self, space: BaseSpace):
+        """Parameter names of the parameterized Spaces enclosing ``space``.
+
+        ``__call__`` assigns a Space's own parameters on every Space in its
+        subtree through ``_mx_assign_params``, and copies the parameters of
+        every enclosing ItemSpace root onto them through ``_mx_copy_params``.
+        A Space class therefore needs slots for the parameters of every
+        parameterized ancestor Space, not only for its own.
+        """
+        result = []
+        parent = space.parent
+        while isinstance(parent, BaseSpace):
+            if parent.formula:
+                result[:0] = get_space_formula_attrs(parent).params
+            parent = parent.parent
+
+        return result
+
+    def slots_decl(self, space: BaseSpace, names, class_names):
+        """Render the ``__slots__`` declaration of ``space``'s class.
+
+        ``names`` are the attributes assigned on instances of the class, in
+        the order they are assigned and possibly with duplicates.
+        ``class_names`` are the names bound in the class body, which a slot
+        must not repeat. Returns an empty string when ``use_slots`` is false,
+        in which case the generated class is byte-identical to the one
+        modelx v0.32.0 generates.
+        """
+        if not self.use_slots:
+            return ''
+
+        slots = []
+        for name in names:
+            if name in class_names:
+                raise ValueError(
+                    "%s cannot be exported with use_slots=True: the name %r "
+                    "is assigned as an attribute of the Space but is also "
+                    "defined as a method of the exported class, most likely "
+                    "by a Cells of the same name. The attribute shadows the "
+                    "method, so the exported model is incorrect for this "
+                    "name either way. Rename one of the two, or pass "
+                    "use_slots=False to export as modelx v0.32.0 does."
+                    % (space.fullname, name))
+            if name not in slots:
+                slots.append(name)
+
+        return self.slots_template.format(
+            names=textwrap.fill(
+                ' '.join("'" + n + "'," for n in slots),
+                width=79,
+                initial_indent=' ' * 8,
+                subsequent_indent=' ' * 8,
+                break_long_words=False,
+                break_on_hyphens=False))
 
     def param_assigns(self, params, copy=False):
         params = list(params)

--- a/modelx/tests/export/test_slots.py
+++ b/modelx/tests/export/test_slots.py
@@ -1,0 +1,489 @@
+"""Tests for exporting Space classes that declare ``__slots__``.
+
+The exporter emits one ``__slots__`` entry per attribute the generated code
+assigns on a Space instance. A name left out of ``__slots__`` is not a
+compile-time error but an ``AttributeError`` the first time the exported model
+runs, so the tests below check the two in both directions:
+
+* every attribute a ``use_slots=False`` export assigns at run time is declared
+  by the matching ``use_slots=True`` class, and
+* the ``use_slots=False`` output is exactly the ``use_slots=True`` output with
+  the ``__slots__`` declarations taken out.
+"""
+import ast
+import importlib
+import math
+import pathlib
+import re
+import sys
+
+import pandas as pd
+import pytest
+
+import modelx as mx
+from modelx.export.exporter import Exporter
+
+
+sample_dir = pathlib.Path(__file__).parent / 'samples'
+
+# Matches a whole ``__slots__`` declaration, including the blank line the
+# class_template reserves for it.
+SLOTS_BLOCK = re.compile(
+    r"\n    __slots__ = \(\n(?:[^\n]*\n)*?    \)\n")
+
+ARGVALS = (1, 2)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+
+def export_both(model, tmp_path, name='Sample'):
+    """Export ``model`` with and without ``__slots__``.
+
+    Returns ``(no_slots_package, slots_package)``, both imported.
+    """
+    result = []
+    for use_slots in (False, True):
+        pkg = name + ('_slots' if use_slots else '_noslots')
+        root = tmp_path / pkg
+        Exporter(model, root, use_slots=use_slots).export()
+        sys.path.insert(0, str(tmp_path))
+        try:
+            for mod in list(sys.modules):
+                if mod == pkg or mod.startswith(pkg + '.'):
+                    del sys.modules[mod]
+            result.append(importlib.import_module(pkg))
+        finally:
+            sys.path.pop(0)
+
+    return tuple(result)
+
+
+def walk_spaces(parent):
+    """Yield every Space below ``parent``, ItemSpaces included."""
+    for space in parent._mx_walk(skip_self=True):
+        yield space
+        for item in list(getattr(space, '_mx_itemspaces', {}).values()):
+            yield from walk_spaces(item)
+            yield item
+
+
+def space_key(space, pkg_name):
+    """A key identifying a Space class across two parallel exports."""
+    module = type(space).__module__
+    return module[len(pkg_name):] + '.' + type(space).__name__
+
+
+def declared_slots(cls):
+    names = set()
+    for klass in cls.__mro__:
+        names.update(getattr(klass, '__slots__', ()))
+    return names
+
+
+def exercise(space, depth=0, max_depth=3):
+    """Call every Cells and create ItemSpaces, recursively.
+
+    Cells that need arguments the caller cannot guess simply raise; the point
+    is to assign as many attributes as possible, not to get right answers.
+    """
+    for sp in space._mx_walk():
+        module = sys.modules[type(sp).__module__]
+        for name in getattr(module, '_v_cells_names_' + sp._name, []):
+            cells = getattr(sp, name)
+            for args in ((), (ARGVALS[0],), ARGVALS):
+                try:
+                    cells(*args)
+                except Exception:
+                    continue
+                break
+        params = getattr(module, '_v_space_params_' + sp._name, [])
+        if params and depth < max_depth:
+            for val in ARGVALS:
+                try:
+                    item = sp(*([val] * len(params)))
+                except Exception:
+                    continue
+                exercise(item, depth + 1, max_depth)
+
+
+def generated_modules(root):
+    return sorted(root.rglob('_mx_classes.py')) + [root / '_mx_model.py']
+
+
+# ---------------------------------------------------------------------------
+# The model under test
+
+@pytest.fixture(scope='module')
+def kitchen_sink(tmp_path_factory):
+    """A model exercising every category of exported Space attribute.
+
+    ``Parent`` is parameterized, so its parameter is assigned on ``Child`` and
+    ``GrandChild`` too, and ``Child``'s parameters are assigned on
+    ``GrandChild``. That propagation is what makes ``__slots__`` easy to get
+    wrong, and no on-disk sample covers it together with the other kinds.
+    """
+    m = mx.new_model('SlotsSample')
+
+    # Model-level (global) Reference
+    m.GlobalConst = 7
+
+    other = m.new_space('Other')
+    other.tag = 'other'
+
+    parent = m.new_space('Parent')
+    child = parent.new_space('Child')
+    grandchild = child.new_space('GrandChild')
+
+    parent.parameters = ('x',)
+    child.parameters = ('y', 'z')
+
+    @mx.defcells(space=parent)
+    def parent_total():
+        return x + GlobalConst
+
+    @mx.defcells(space=child)
+    def child_sum():
+        return x + y + z
+
+    @mx.defcells(space=child)
+    def scaled(n):
+        return n * ratio
+
+    @mx.defcells(space=child)
+    def uncached(n):
+        return n + x
+
+    child.uncached.is_cached = False
+
+    @mx.defcells(space=grandchild)
+    def deepest():
+        return x * y * z
+
+    # References of every kind ref_value() handles
+    child.ratio = 2.5                       # literal float
+    child.label = 'child'                   # literal str
+    child.flag = True                       # literal bool
+    child.nothing = None                    # literal None
+    child.math = math                       # module
+    child.pickled = [1, 2, 3]               # pickled
+    child.set_ref('sibling', other, refmode='absolute')      # Interface
+    child.set_ref('up', parent, refmode='auto')              # Interface
+
+    grandchild.new_pandas(
+        'table', 'table.csv',
+        pd.DataFrame({'a': [1, 2, 3], 'b': [4.0, 5.0, 6.0]}),
+        file_type='csv')
+
+    @mx.defmacro
+    def sample_macro(a):
+        return a + mx_model.GlobalConst
+
+    yield m
+    m.close()
+
+
+@pytest.fixture(scope='module')
+def kitchen_sink_exports(kitchen_sink, tmp_path_factory):
+    path = tmp_path_factory.mktemp('slots')
+    no_slots, slots = export_both(kitchen_sink, path, 'SlotsSample')
+    exercise(no_slots.mx_model)
+    exercise(slots.mx_model)
+    return no_slots, slots
+
+
+# ---------------------------------------------------------------------------
+# The equivalence test: __slots__ must cover everything actually assigned
+
+SAMPLE_MODELS = [
+    'ConstExample', 'FixedMortgage', 'ModelPath', 'NestedParams',
+    'NestedSpace', 'Options', 'PandasData', 'Params', 'RelativeRefs',
+    'RelativeRefs2', 'SampleSubscript',
+]
+
+# EmptyModel has no Space at all, so it has nothing to declare slots for.
+BYTE_IDENTICAL_MODELS = SAMPLE_MODELS + ['EmptyModel']
+
+
+def assert_slots_cover_dicts(no_slots, slots):
+    """Every attribute the no-slots export assigns must have a slot."""
+    used = {}
+    for space in walk_spaces(no_slots.mx_model):
+        key = space_key(space, no_slots.__name__)
+        used.setdefault(key, set()).update(vars(space))
+
+    available = {}
+    for space in walk_spaces(slots.mx_model):
+        available[space_key(space, slots.__name__)] = declared_slots(type(space))
+
+    assert used, 'the model under test has no Spaces'
+    for key, names in sorted(used.items()):
+        assert key in available
+        assert not (names - available[key]), (
+            '%s assigns %s but does not declare it in __slots__'
+            % (key, sorted(names - available[key])))
+
+
+@pytest.mark.parametrize('name', SAMPLE_MODELS)
+def test_slots_cover_assigned_attributes(name, tmp_path):
+    m = mx.read_model(sample_dir / name)
+    try:
+        no_slots, slots = export_both(m, tmp_path, name)
+        exercise(no_slots.mx_model)
+        exercise(slots.mx_model)
+        assert_slots_cover_dicts(no_slots, slots)
+    finally:
+        m.close()
+
+
+def test_slots_cover_assigned_attributes_kitchen_sink(kitchen_sink_exports):
+    assert_slots_cover_dicts(*kitchen_sink_exports)
+
+
+def test_slots_cover_class_body_assignments(kitchen_sink_exports):
+    """Static counterpart of the run-time check above.
+
+    Reads the generated source instead of running it, so a Space whose Cells
+    the run-time check could not call is still covered.
+    """
+    _, slots = kitchen_sink_exports
+    root = pathlib.Path(slots.__file__).parent
+    checked = 0
+    for path in root.rglob('_mx_classes.py'):
+        tree = ast.parse(path.read_text(encoding='utf-8'))
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef):
+                continue
+            declared = set()
+            assigned = set()
+            for sub in ast.walk(node):
+                if not isinstance(sub, (ast.Assign, ast.AugAssign)):
+                    continue
+                targets = (sub.targets if isinstance(sub, ast.Assign)
+                           else [sub.target])
+                for target in targets:
+                    if (isinstance(target, ast.Name)
+                            and target.id == '__slots__'):
+                        declared = {elt.value for elt in sub.value.elts}
+                    elif (isinstance(target, ast.Attribute)
+                          and isinstance(target.value, ast.Name)
+                          and target.value.id in
+                          ('self', '_mx_space', 'other')):
+                        assigned.add(target.attr)
+            assert declared, '%s declares no __slots__' % node.name
+            assert not (assigned - declared), (
+                '%s assigns %s but does not declare it in __slots__'
+                % (node.name, sorted(assigned - declared)))
+            checked += 1
+
+    assert checked == 4    # Other, Parent, Child, GrandChild
+
+
+def test_inherited_parameters_are_declared(kitchen_sink_exports):
+    """The parameters of every parameterized ancestor need a slot.
+
+    ``__call__`` assigns them through ``_mx_assign_params`` and
+    ``_mx_copy_params`` on every Space in the subtree, not just on the Space
+    that owns the formula.
+    """
+    _, slots = kitchen_sink_exports
+    child = type(slots.mx_model.Parent.Child)
+    grandchild = type(slots.mx_model.Parent.Child.GrandChild)
+
+    assert 'x' in child.__slots__
+    assert set(('x', 'y', 'z')) <= set(grandchild.__slots__)
+
+
+def test_nested_parameters_run(tmp_path):
+    """The values of test_itemspace_nested_params, under both settings."""
+    m = mx.read_model(sample_dir / 'NestedParams')
+    try:
+        for nomx in export_both(m, tmp_path, 'NestedParams'):
+            model = nomx.mx_model
+            assert model.Parent[1].x == 1
+            assert model.Parent[1].Child.x == 1
+            assert model.Parent[1].Child[2].x == 1
+            assert model.Parent[1].Child[2].y == 2
+            assert model.Parent[2].Child[3].x == 2
+            assert model.Parent[2].Child[3].y == 3
+            assert model.Parent[2].Child[3].SubChild.baz == 1
+    finally:
+        m.close()
+
+
+# ---------------------------------------------------------------------------
+# use_slots=False must reproduce the previous output exactly
+
+def strip_slots(code):
+    return SLOTS_BLOCK.sub('', code)
+
+
+@pytest.mark.parametrize('name', BYTE_IDENTICAL_MODELS)
+def test_use_slots_false_output_unchanged(name, tmp_path):
+    """``use_slots=False`` output is the slots output minus the declarations.
+
+    The declarations are the only difference the flag is allowed to make, so
+    the two exports must match once they are removed.
+    """
+    m = mx.read_model(sample_dir / name)
+    try:
+        no_slots_dir = tmp_path / 'noslots'
+        slots_dir = tmp_path / 'slots'
+        Exporter(m, no_slots_dir, use_slots=False).export()
+        Exporter(m, slots_dir, use_slots=True).export()
+
+        checked = 0
+        for plain in generated_modules(no_slots_dir):
+            slotted = slots_dir / plain.relative_to(no_slots_dir)
+            assert slotted.exists()
+            plain_code = plain.read_text(encoding='utf-8')
+            slotted_code = slotted.read_text(encoding='utf-8')
+            if '(_mx_sys.BaseSpace):' in slotted_code:
+                assert '__slots__' in slotted_code
+            assert strip_slots(slotted_code) == plain_code
+            checked += 1
+
+        assert checked
+    finally:
+        m.close()
+
+
+def test_mx_sys_is_copied_verbatim(tmp_path):
+    """_mx_sys.py is a static template and does not depend on the flag."""
+    from modelx.export import exporter
+
+    m = mx.read_model(sample_dir / 'Options')
+    try:
+        source = (pathlib.Path(exporter.__file__).parent
+                  / '_mx_sys.py').read_bytes()
+        for use_slots in (False, True):
+            out = tmp_path / str(use_slots)
+            Exporter(m, out, use_slots=use_slots).export()
+            assert (out / '_mx_sys.py').read_bytes() == source
+    finally:
+        m.close()
+
+
+# ---------------------------------------------------------------------------
+# Instance layout
+
+def test_spaces_have_no_dict_under_slots(kitchen_sink_exports):
+    no_slots, slots = kitchen_sink_exports
+
+    for space in walk_spaces(slots.mx_model):
+        assert not hasattr(space, '__dict__'), type(space).__name__
+
+    # The Model class is deliberately left alone.
+    assert hasattr(slots.mx_model, '__dict__')
+
+    # Adding __slots__ to the _mx_sys base classes does not take the __dict__
+    # away from classes that declare none of their own.
+    for space in walk_spaces(no_slots.mx_model):
+        assert hasattr(space, '__dict__'), type(space).__name__
+
+
+def test_weakref_unsupported_under_slots(kitchen_sink_exports):
+    """Documented consequence: no __weakref__ slot is declared."""
+    import weakref
+
+    no_slots, slots = kitchen_sink_exports
+    weakref.ref(no_slots.mx_model.Parent)       # unchanged
+    with pytest.raises(TypeError):
+        weakref.ref(slots.mx_model.Parent)
+
+
+# ---------------------------------------------------------------------------
+# Results are the same either way
+
+def test_values_identical(kitchen_sink_exports, kitchen_sink):
+    no_slots, slots = kitchen_sink_exports
+    m = kitchen_sink
+
+    for pkg in (no_slots, slots):
+        nomx = pkg.mx_model
+        assert nomx.Parent[3].parent_total() == m.Parent[3].parent_total()
+        assert (nomx.Parent[3].Child[4, 5].child_sum()
+                == m.Parent[3].Child[4, 5].child_sum())
+        assert (nomx.Parent[3].Child[4, 5].scaled(2)
+                == m.Parent[3].Child[4, 5].scaled(2))
+        assert (nomx.Parent[3].Child[4, 5].uncached(2)
+                == m.Parent[3].Child[4, 5].uncached(2))
+        assert (nomx.Parent[3].Child[4, 5].GrandChild.deepest()
+                == m.Parent[3].Child[4, 5].GrandChild.deepest())
+        assert nomx.Parent.Child.sibling is nomx.Other
+        assert nomx.Parent.Child.up is nomx.Parent
+        assert nomx.Parent.Child.math is math
+        assert nomx.Parent.Child.pickled == [1, 2, 3]
+        assert pkg.sample_macro(1) == m.sample_macro(1)
+        pd.testing.assert_frame_equal(
+            nomx.Parent.Child.GrandChild.table,
+            m.Parent.Child.GrandChild.table)
+
+
+# ---------------------------------------------------------------------------
+# The API
+
+@pytest.mark.parametrize('api', ['function', 'method', 'exporter'])
+def test_use_slots_keyword(api, tmp_path):
+    m = mx.read_model(sample_dir / 'Options')
+    try:
+        for use_slots in (False, True):
+            out = tmp_path / (api + str(use_slots))
+            if api == 'function':
+                mx.export_model(m, out, use_slots=use_slots)
+            elif api == 'method':
+                m.export(out, use_slots=use_slots)
+            else:
+                Exporter(m, out, use_slots=use_slots).export()
+
+            code = (out / '_mx_classes.py').read_text(encoding='utf-8')
+            assert ('__slots__' in code) is use_slots
+    finally:
+        m.close()
+
+
+def test_slots_default_is_on(tmp_path):
+    m = mx.read_model(sample_dir / 'Options')
+    try:
+        mx.export_model(m, tmp_path / 'default')
+        code = (tmp_path / 'default' / '_mx_classes.py').read_text(
+            encoding='utf-8')
+        assert '__slots__' in code
+    finally:
+        m.close()
+
+
+# ---------------------------------------------------------------------------
+# Name clashes
+
+def test_parameter_clashing_with_cells_is_rejected(tmp_path):
+    """A slot may not repeat a name bound in the class body.
+
+    A Cells named after a parameter of an enclosing Space is already broken in
+    the exported model - the parameter assignment shadows the method - but
+    under use_slots=True it would fail at class creation with a message
+    pointing at the generated file, so the exporter rejects it up front.
+    """
+    m = mx.new_model('SlotsClash')
+    try:
+        parent = m.new_space('Parent')
+        child = parent.new_space('Child')
+        parent.parameters = ('t',)
+
+        @mx.defcells(space=child)
+        def t():
+            return 99
+
+        with pytest.raises(ValueError) as excinfo:
+            m.export(tmp_path / 'clash')
+
+        message = str(excinfo.value)
+        assert 'SlotsClash.Parent.Child' in message
+        assert "'t'" in message
+        assert 'use_slots=False' in message
+
+        # The previous behaviour stays available.
+        m.export(tmp_path / 'noclash', use_slots=False)
+        assert (tmp_path / 'noclash' / '_m_Parent' / '_mx_classes.py').exists()
+    finally:
+        m.close()

--- a/modelx/tests/export/test_slots.py
+++ b/modelx/tests/export/test_slots.py
@@ -27,10 +27,12 @@ from modelx.export.exporter import Exporter
 
 sample_dir = pathlib.Path(__file__).parent / 'samples'
 
-# Matches a whole ``__slots__`` declaration, including the blank line the
-# class_template reserves for it.
+# A whole ``__slots__`` declaration together with the blank line the
+# class_template reserves for it. Anchored on the class statement so that a
+# Cells docstring holding a line that looks like one cannot match.
 SLOTS_BLOCK = re.compile(
-    r"\n    __slots__ = \(\n(?:[^\n]*\n)*?    \)\n")
+    r"(?m)^(class _c_\w+\(_mx_sys\.BaseSpace\):\n)\n"
+    r"    __slots__ = \(\n(?:[^\n]*\n)*?    \)\n")
 
 ARGVALS = (1, 2)
 
@@ -322,7 +324,7 @@ def test_nested_parameters_run(tmp_path):
 # use_slots=False must reproduce the previous output exactly
 
 def strip_slots(code):
-    return SLOTS_BLOCK.sub('', code)
+    return SLOTS_BLOCK.sub(r'\1', code)
 
 
 @pytest.mark.parametrize('name', BYTE_IDENTICAL_MODELS)

--- a/modelx/tests/export/test_slots.py
+++ b/modelx/tests/export/test_slots.py
@@ -503,9 +503,11 @@ def test_parameter_clashing_with_inherited_member_is_rejected(param, tmp_path):
     """A slot may not repeat a member of the _mx_sys base classes either.
 
     CPython raises nothing for these: the slot silently shadows the member,
-    which kills the ``_cells`` property and ``_mx_walk``. Space parameters are
-    the only names that can reach ``__slots__`` with a leading underscore -
-    modelx rejects one in the name of a Cells, a Reference or a Space.
+    which kills the ``_cells`` property and ``_mx_walk``. Every inherited
+    member starts with an underscore, and a Space parameter is the only slot
+    name that can: modelx rejects a leading underscore in the name of a
+    Reference or a Space, and renames such a Cells, whose name in any case
+    only reaches ``__slots__`` behind a ``_v_`` or ``_has_`` prefix.
     """
     m = mx.new_model('SlotsInherited')
     try:
@@ -568,5 +570,66 @@ def test_macro_cannot_create_a_reference_under_slots(tmp_path):
         with pytest.raises(AttributeError) as excinfo:
             slots.add_ref()
         assert 'added' in str(excinfo.value)
+    finally:
+        m.close()
+
+
+def test_non_normalised_names_are_declared_as_stored(tmp_path):
+    """Python normalises identifiers to NFKC; a ``__slots__`` string is not.
+
+    A fullwidth letter is what a name pasted out of a spreadsheet carries, and
+    :meth:`str.isidentifier` accepts it, so modelx keeps it verbatim. The
+    generated ``self.<name> = ...`` compiles to the normalised name, so the
+    slot has to carry the normalised name too or the exported package does not
+    even import.
+    """
+    ref_name = chr(0xFF32) + 'ate'      # FULLWIDTH LATIN CAPITAL LETTER R
+    param_name = chr(0xFF54)            # FULLWIDTH LATIN SMALL LETTER T
+
+    m = mx.new_model('SlotsUnicode')
+    try:
+        parent = m.new_space('Parent')
+        child = parent.new_space('Child')
+        setattr(child, ref_name, 0.03)
+        parent.parameters = (param_name,)
+
+        no_slots, slots = export_both(m, tmp_path, 'SlotsUnicode')
+        declared = declared_slots(type(slots.mx_model.Parent.Child))
+        assert 'Rate' in declared
+        assert 't' in declared
+
+        for nomx in (no_slots.mx_model, slots.mx_model):
+            assert nomx.Parent.Child.Rate == 0.03
+            assert nomx.Parent[9].Child.t == 9
+        assert_slots_cover_dicts(no_slots, slots)
+    finally:
+        m.close()
+
+
+def test_reference_named_after_a_cells_is_rejected(tmp_path):
+    """The guard covers References, not only parameters.
+
+    ``space.refs`` includes the model-level globals, so a global sharing its
+    name with a Cells of the Space is assigned over the Cells method. modelx
+    v0.32.0 exports the alias case below correctly, because ``self.rate =
+    self.rate`` resolves to the same bound method, but ``__slots__`` cannot
+    declare the name at all while the class body defines the method.
+    """
+    m = mx.new_model('SlotsGlobalRef')
+    try:
+        space = m.new_space('Space1')
+
+        @mx.defcells(space=space)
+        def rate(x):
+            return 2 * x
+
+        m.rate = space.rate     # a model-level alias for the Cells
+
+        with pytest.raises(ValueError) as excinfo:
+            m.export(tmp_path / 'clash')
+        assert "'rate'" in str(excinfo.value)
+        assert 'SlotsGlobalRef.Space1' in str(excinfo.value)
+
+        m.export(tmp_path / 'noclash', use_slots=False)
     finally:
         m.close()

--- a/modelx/tests/export/test_slots.py
+++ b/modelx/tests/export/test_slots.py
@@ -16,6 +16,7 @@ import math
 import pathlib
 import re
 import sys
+import types
 
 import pandas as pd
 import pytest
@@ -75,9 +76,15 @@ def space_key(space, pkg_name):
 
 
 def declared_slots(cls):
+    """Names of the slot descriptors cls and its bases really have.
+
+    Not the __slots__ tuples themselves: CPython mangles a private name
+    in __slots__ with the class that declares it.
+    """
     names = set()
     for klass in cls.__mro__:
-        names.update(getattr(klass, '__slots__', ()))
+        names.update(name for name, value in vars(klass).items()
+                     if isinstance(value, types.MemberDescriptorType))
     return names
 
 
@@ -485,5 +492,79 @@ def test_parameter_clashing_with_cells_is_rejected(tmp_path):
         # The previous behaviour stays available.
         m.export(tmp_path / 'noclash', use_slots=False)
         assert (tmp_path / 'noclash' / '_m_Parent' / '_mx_classes.py').exists()
+    finally:
+        m.close()
+
+
+@pytest.mark.parametrize('param', ['_cells', '_mx_walk'])
+def test_parameter_clashing_with_inherited_member_is_rejected(param, tmp_path):
+    """A slot may not repeat a member of the _mx_sys base classes either.
+
+    CPython raises nothing for these: the slot silently shadows the member,
+    which kills the ``_cells`` property and ``_mx_walk``. Space parameters are
+    the only names that can reach ``__slots__`` with a leading underscore -
+    modelx rejects one in the name of a Cells, a Reference or a Space.
+    """
+    m = mx.new_model('SlotsInherited')
+    try:
+        space = m.new_space('Space1')
+        space.parameters = (param,)
+
+        with pytest.raises(ValueError) as excinfo:
+            m.export(tmp_path / 'clash')
+
+        assert repr(param) in str(excinfo.value)
+        m.export(tmp_path / 'noclash', use_slots=False)
+    finally:
+        m.close()
+
+
+def test_private_parameter_name_is_mangled(tmp_path):
+    """A private parameter is written under the owning class's mangled name.
+
+    ``_mx_assign_params`` is compiled in the body of the Space that owns the
+    parameter, so ``__x`` reaches a descendant as ``_c_<Owner>__x``. A
+    ``__slots__`` string is mangled with the class that declares it, so the
+    descendant has to name the owner's form.
+    """
+    m = mx.new_model('SlotsPrivate')
+    try:
+        parent = m.new_space('Parent')
+        parent.new_space('Child')
+        parent.parameters = ('__x',)
+
+        no_slots, slots = export_both(m, tmp_path, 'SlotsPrivate')
+        assert '_c_Parent__x' in type(slots.mx_model.Parent.Child).__slots__
+
+        for nomx in (no_slots.mx_model, slots.mx_model):
+            assert nomx.Parent[5].Child is not None
+        assert_slots_cover_dicts(no_slots, slots)
+    finally:
+        m.close()
+
+
+def test_macro_cannot_create_a_reference_under_slots(tmp_path):
+    """The attributes of a Space class are fixed when the model is exported.
+
+    A macro that assigns a Reference the model does not already have works on
+    the live model and in a use_slots=False export. It cannot work under
+    __slots__, because the name is unknown when the class is generated. The
+    failure is loud and names the attribute, which is why it is documented
+    rather than guarded against.
+    """
+    m = mx.new_model('SlotsMacro')
+    try:
+        m.new_space('Space1')
+
+        @mx.defmacro
+        def add_ref():
+            mx_model.Space1.added = 123
+            return mx_model.Space1.added
+
+        no_slots, slots = export_both(m, tmp_path, 'SlotsMacro')
+        assert no_slots.add_ref() == 123
+        with pytest.raises(AttributeError) as excinfo:
+            slots.add_ref()
+        assert 'added' in str(excinfo.value)
     finally:
         m.close()


### PR DESCRIPTION
Generated Space classes now declare `__slots__`. CPython keeps slotted attributes in a fixed-size array instead of an instance dictionary and specialises the bytecode that reads them, so an exported model runs faster and takes less memory. A new `use_slots` keyword on `export_model()`, `Model.export()` and `Exporter()` turns the declarations off.

The motivation is a CPython 3.14 change (`5d3201fe` / gh-123219) that stopped specialising `LOAD_ATTR` for instance attributes outside a type's 30-entry shared-key table. `_c_Projection` of lifelib's `BasicTerm_SC` has 73 attributes, so all 39 `_v_*` memo caches fell off the fast path. `__slots__` is not just a 3.14 workaround, though — it is a solid win on 3.13 too.

## Measurements

lifelib `basiclife/BasicTerm_SC`, 3,000 model points per round, best of three, identical checksums both ways:

| export style | Python 3.13.9 | Python 3.14.6 | ItemSpace |
| --- | ---: | ---: | ---: |
| as generated today | 3.68 s | 3.22 s | 1,632 bytes |
| `__slots__` | **2.90 s** | **2.31 s** | **616 bytes** |

## What is in the diff

- `use_slots=True` on `export_model()`, `Model.export()` and `Exporter.__init__`, threaded to `SpaceTranslator`.
- `__slots__ = ()` on `BaseMxObject` / `BaseParent` / `BaseSpace` in the `_mx_sys.py` template, in **both** modes. A subclass that declares no `__slots__` of its own still gets a `__dict__`, so `use_slots=False` is unaffected. `BaseModel` and the generated model class are left alone deliberately — the model class carries arbitrary Reference names and there is one instance.
- A `{slots_decl}` placeholder in `SpaceTranslator.class_template`, expanding to the empty string under `use_slots=False`.
- No `__weakref__` slot, by decision.

A name missing from `__slots__` is an `AttributeError` at run time, not a compile-time error, so each slot name is collected next to the statement that assigns the attribute. `ref_names()` and `space_names()` are now the single source of truth for the References and the child Spaces, shared by the assignment emitters and the slot list.

### The propagation rule

`__call__` assigns a Space's own parameters onto **every** Space in its subtree through `_mx_assign_params`, and replays every enclosing ItemSpace root's `_mx_copy_params` as well. A Space class therefore declares the parameters of every parameterized ancestor, not only its own — `_c_SubChild` of the `NestedParams` sample needs slots for `Parent`'s `x` and `Child`'s `y` although it has no parameters of its own.

### Names `__slots__` cannot express

A Space parameter is the only name that reaches `__slots__` with a leading underscore — modelx rejects one in the name of a Reference or a Space, and a Cells name only ever arrives behind a `_v_` or `_has_` prefix. Three cases needed handling:

- **A name the class body binds** (a Cells sharing its name with a parameter, or with a Reference including a model-level global) makes `type.__new__` raise, so the whole `_mx_classes.py` fails to import. The exporter now raises `ValueError` at export time instead, naming the Space and the name and pointing at `use_slots=False`.
- **A name inherited from the `_mx_sys` template** (`_cells`, `_mx_walk`, …) gets no error from CPython at all: the slot silently shadows the member. A parameter named `_cells` would take over the property that populates `_mx_cells`. The reserved set is read from `_mx_sys.BaseSpace.__mro__` rather than listed, so it cannot fall behind the template.
- **A private name** (`__x`) is mangled with the class body it is written from, and a `__slots__` string is mangled with the class that declares it, so a descendant must declare `_c_<Owner>__x`. Without that, creating any ItemSpace of such a Space raised `AttributeError` although it works today.
- **A non-NFKC name.** Python normalises every identifier in a source file; a `__slots__` string is only mangled, never normalised. `str.isidentifier()` accepts a fullwidth letter and modelx keeps the name verbatim, so a Reference named `Ｒate` was assigned as `self.Rate` and declared as `'Ｒate'`, and the exported package did not import at all. Slot names, the guarded names and the mangling class name are all normalised now.

## Verification

- **`use_slots=False` is byte-identical to v0.32.0** across all 44 generated modules of 10 sample models. Only `_mx_sys.py` differs, in both modes, because it is copied verbatim and now carries `__slots__ = ()` on the base classes.
- **`__slots__` covers every attribute a `use_slots=False` export actually assigns at run time**, checked over 12 sample models and 6 lifelib models including `TradLife_A` (14 classes) and `IntegratedLife` (9), with the models exercised until ItemSpaces are created three levels deep.
- Full suite green on Python 3.13 (1447 passed, 6 skipped) and the export suite on 3.12. Docs build adds no warnings.
- New `modelx/tests/export/test_slots.py`: the slots-cover-`__dict__` equivalence test over every sample plus a model with nested Spaces under a parameterized Space, multiple parameters, cacheless Cells, model-level globals, macros and every Reference kind `ref_value()` handles; a static per-class assignment scan; byte-identity of the two modes; no `__dict__` under slots; and one test per rejected name.

## For the reviewer

Two consequences are documented rather than guarded, both loud and both with an obvious workaround:

- The attributes of a Space class are fixed at export time, so a **macro or formula that assigns a Reference the model does not already have** raises `AttributeError` in the exported model. The name is not knowable when the class is generated. The task memo's "macros are not affected" is true about where macros live, not about what they do.
- Exported Space objects are **not weak-referenceable**, have no `__dict__`, and cannot be pickled with pickle protocol 0 or 1.

Two things worth an explicit decision:

1. **The new `ValueError` refuses one model that exports correctly today.** `m.alias = m.S.cells` — a model-level Reference aliasing a Cells — generates `self.rate = self.rate`, which resolves to the same bound method and is a no-op, so v0.32.0 exports it correctly. It cannot be slotted at all while the class body defines the method, so the export is refused; the message no longer claims the export was already wrong. Falling back to an unslotted class for that one Space would be the alternative.
2. **`modelx-cython` breaks on `use_slots=True` output** — `tracer.py` reads the traced Space's `__dict__` to discover its refs. That single line is the only blocker; compiled models were never affected by the CPython regression in the first place, since `@cy.cclass` turns attributes into C struct fields. Fixing it is out of scope here and is recorded in `devnotes/DependentPackages.md` §2.2, but with `use_slots=True` as the default the two releases need coordinating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
