### PR TITLE
DIST: Release v0.33.0

### DIFF
--- a/doc/source/releases/relnotes_v0_33_0.rst
+++ b/doc/source/releases/relnotes_v0_33_0.rst
@@ -1,5 +1,5 @@
 ====================================
-modelx v0.33.0 (not yet released)
+modelx v0.33.0 (5 September 2026)
 ====================================
 
 This release introduces the following enhancements, backward-incompatible
@@ -16,6 +16,31 @@ Anaconda users should use the ``conda`` command instead::
 
 Enhancements
 ============
+
+* Calling a Cells is faster (`GH269`_). modelx identifies a Cells value by a
+  key built from the arguments of the call, and until this release that key
+  was always built with :meth:`inspect.Signature.bind`. Because the value
+  cache is consulted only after the key exists, a call that merely returned
+  an already calculated value paid for a full ``bind()`` as well.
+
+  A Formula now derives from its signature, once when it is created, the
+  defaults to append to each possible number of positional arguments, and a
+  call that passes all of its arguments positionally builds the key from
+  that instead. Calls passing keyword arguments, and formulas whose
+  signature has ``*args``, ``**kwargs`` or keyword-only parameters, take the
+  previous path unchanged, and a call with arguments the formula does not
+  accept still raises the same :obj:`TypeError` with the same message.
+
+  Measured over a sweep of 28 lifelib models, calling
+  ``Projection[i].result_cf()`` for each of 234 model points and producing
+  byte-identical results, the sweep runs 24% to 30% faster.
+
+* :meth:`Model.export<modelx.core.model.Model.export>` and
+  :func:`~modelx.export_model` are no longer experimental. The export
+  feature was introduced in modelx v0.22.0 and has carried an experimental
+  warning since then; the warning is now removed. The limitations of the
+  export, which are unchanged, remain documented under
+  :func:`~modelx.export_model`.
 
 * The Space classes that
   :meth:`Model.export<modelx.core.model.Model.export>` and
@@ -55,8 +80,11 @@ Enhancements
   cached, the exported ``TradLife_A`` projects 2.2 times as many model points
   per second with 8 threads as with one, and the same export compiled with
   `modelx-cython <https://github.com/fumitoh/modelx-cython>`_ 3.3 times as
-  many; the lock costs nothing measurable single-threaded.
+  many; the lock costs nothing measurable single-threaded. Compiling an
+  export made with ``locked_spaces`` requires modelx-cython v0.1.0 or later.
   See :func:`~modelx.export_model` for the guarantees and their limits.
+
+.. _GH269: https://github.com/fumitoh/modelx/pull/269
 
 
 Backward Incompatible Changes
@@ -68,10 +96,6 @@ Backward Incompatible Changes
   in the exported model. Space objects there are also no longer
   weak-referenceable, have no ``__dict__``, and cannot be pickled with pickle
   protocol 0 or 1.
-  `modelx-cython <https://github.com/fumitoh/modelx-cython>`_ cannot compile a
-  model exported this way either, until it is updated to read ``__slots__``,
-  nor a model exported with ``locked_spaces`` until it is updated to
-  translate the lock.
   Export with ``use_slots=False`` in any of these cases.
 
 * :meth:`Model.export<modelx.core.model.Model.export>` and

--- a/doc/source/updates.rst
+++ b/doc/source/updates.rst
@@ -12,6 +12,9 @@ Updates
     Visit <a href="https://github.com/fumitoh/modelx/discussions" target="_blank">Discussions</a>
     for more frequent updates.</p>
 
+* *5 September 2026:*
+  modelx v0.33.0 is released. See :doc:`releases/relnotes_v0_33_0`.
+
 * *8 August 2026:*
   modelx v0.32.0 is released. See :doc:`releases/relnotes_v0_32_0`.
 

--- a/modelx/__init__.py
+++ b/modelx/__init__.py
@@ -20,7 +20,7 @@ Attributes:
 
 """
 
-VERSION = (0, 32, 0)
+VERSION = (0, 33, 0)
 __version__ = ".".join([str(x) for x in VERSION])
 from modelx.core.api import *  # must come after __version__ assignment.
 try:

--- a/modelx/core/api.py
+++ b/modelx/core/api.py
@@ -1351,9 +1351,6 @@ def handle_formula_error(handle=None):
 def export_model(model, path, use_slots=True, locked_spaces=None):
     """Export a given model as a self-contained Python package.
 
-    .. warning:: This function is currently experimental
-            and subject to limitations detailed below.
-
     This function exports the provided ``model`` as a Python package.
     The resulting package is self-contained, meaning it does not require modelx.
 
@@ -1380,8 +1377,7 @@ def export_model(model, path, use_slots=True, locked_spaces=None):
 
     **Limitations**
 
-    As this function is currently experimental,
-    not all modelx models can be exported. Current limitations include:
+    Not all modelx models can be exported. Current limitations include:
 
     * Relative references in ItemSpaces are not supported.
       All references within an ItemSpace are bound
@@ -1416,8 +1412,6 @@ def export_model(model, path, use_slots=True, locked_spaces=None):
       ``__slots__`` cannot declare it. In practice that is a Cells sharing
       its name with a parameter of its own Space or of an enclosing Space,
       or with a Reference, including a model-level global.
-    * `modelx-cython`_ cannot compile an export made this way until it is
-      updated.
 
     Pass ``use_slots=False`` in any of these cases to export as
     modelx v0.32.0 and earlier does.
@@ -1479,8 +1473,8 @@ def export_model(model, path, use_slots=True, locked_spaces=None):
       re-enables the GIL when imported, with a warning. pandas 2 is one;
       run Python with the environment variable ``PYTHON_GIL=0`` to keep the
       GIL disabled in that case.
-    * `modelx-cython`_ v0.0.9 and earlier cannot compile a model exported
-      with ``locked_spaces``.
+    * Compiling a model exported with ``locked_spaces`` requires
+      `modelx-cython`_ v0.1.0 or later.
 
     .. _modelx-cython: https://github.com/fumitoh/modelx-cython
 

--- a/modelx/core/model.py
+++ b/modelx/core/model.py
@@ -563,11 +563,9 @@ class Model(IOSpecOperation, EditableParent):
     def export(self, path, use_slots=True, locked_spaces=None):
         """Export the model as a Python package.
 
-        .. warning:: This feature is experimental.
-            See the limitaions section in :py:func:`~modelx.export_model`.
-
         This method performs the :py:func:`~modelx.export_model`
-        on self. See :py:func:`~modelx.export_model` section for the details.
+        on self. See :py:func:`~modelx.export_model` section for the
+        details, including the limitations of the export.
 
         Args:
             path: The path where the generated Python package will be located.


### PR DESCRIPTION
Prepares the v0.33.0 release: version bump plus the documentation changes that go with it.

## Changes

**Export is no longer experimental.** Dropped the `.. warning::` admonition from both `export_model` and `Model.export`. The feature landed in v0.22.0 and has carried the warning since. The Limitations section stays put, with its preamble reworded so it no longer leans on "as this function is currently experimental" — the limitations themselves are unchanged.

**modelx-cython.** Removed the note saying modelx-cython cannot compile a `__slots__` export until it is updated, from both the `export_model` docstring and the release notes. The `locked_spaces` caveat is now phrased as a minimum version requirement (modelx-cython v0.1.0 or later) rather than naming the versions that cannot compile it.

**Release notes.** Dated the notes 5 September 2026, and added a missing Enhancements entry for the `Signature.bind()` fast path (#269) — a 24–30% speedup on the 28-model lifelib sweep that was absent from the draft and is the largest user-visible change since v0.32.0.

**Version.** `VERSION = (0, 33, 0)`. No serializer change this release, so `_MX_TO_FORMAT` and `HIGHEST_VERSION` are untouched.

Also adds the `updates.rst` entry for v0.33.0. Deliberately **no** modelx-cython entry there: v0.1.0 is ready for its version bump but is not released yet.

## Not included

The `_copy_other()` / `ParamFunc.__slots__ = ()` fix that rode along in #269 is left out of the release notes. It is only reachable by passing modelx's internal `NULL_FORMULA` to `set_formula`, so it reads as internal robustness rather than a user-facing bug fix. Easy to add if you'd rather it appear.

## Verification

- Full test suite: 1488 passed, 7 skipped.
- Sphinx build succeeds. The only 3 warnings are pre-existing `toc.not_included` for untracked tutorial files (`debugging.rst`, `save_and_restore.rst`, `eval_formulas.rst`).
- Rendered docs reviewed in a browser: both API pages show zero "experimental" mentions, `inspect.Signature.bind` resolves through intersphinx, and the `GH269` link resolves to PR #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
